### PR TITLE
Add PartnerBar after hero

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -150,6 +150,65 @@ const Hero = () => {
   );
 };
 
+// Partner Bar Component
+const PartnerBar = () => {
+  const { t } = useLanguage();
+
+  const partners = [
+    {
+      name: 'Microsoft for Startups',
+      logo:
+        'https://github.com/simondadiamond/workflowleaf-assets/blob/1ae5d2c4fc3b285cdd60ed5b3c986f0e14a3c4b7/partner-bar/Microsoft%20Startups.png?raw=true'
+    },
+    {
+      name: 'DigitalOcean Hatch',
+      logo:
+        'https://github.com/simondadiamond/workflowleaf-assets/blob/07e0a1d79616959fc3294b71c06da22e0078914d/partner-bar/hatch.png?raw=true'
+    },
+    {
+      name: 'Stripe',
+      logo:
+        'https://github.com/simondadiamond/workflowleaf-assets/blob/1ae5d2c4fc3b285cdd60ed5b3c986f0e14a3c4b7/partner-bar/Stripe%20Logo.svg?raw=true'
+    },
+    {
+      name: 'Airtable',
+      logo:
+        'https://github.com/simondadiamond/workflowleaf-assets/blob/1ae5d2c4fc3b285cdd60ed5b3c986f0e14a3c4b7/partner-bar/Airtable.png?raw=true'
+    }
+  ];
+
+  const numberOfRepetitions = 6;
+  const repeatedPartners = Array(numberOfRepetitions).fill(partners).flat();
+
+  return (
+    <section className="py-12" style={{ background: '#121C2D' }}>
+      <div className="max-w-8xl mx-auto px-4 sm:px-6 lg:px-8">
+        <h2 className="text-center text-sm font-semibold tracking-wider uppercase font-mono mb-8 text-white">
+          {t.partners.title}
+        </h2>
+
+        <div className="overflow-hidden w-full">
+          <div className="flex w-max animate-scroll space-x-24 items-center">
+            {repeatedPartners.map((partner, index) => (
+              <div
+                key={`${partner.name}-${index}`}
+                className="flex-shrink-0 h-9 w-auto grayscale opacity-70 hover:grayscale-0 hover:opacity-100 transition-all duration-300"
+                title={partner.name}
+              >
+                <img
+                  src={partner.logo}
+                  alt={`${partner.name} logo`}
+                  className="h-full w-auto object-contain"
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
 // Problem Section Component
 const ProblemSection = () => {
   const [isVisible, setIsVisible] = useState(false);
@@ -822,6 +881,7 @@ function App() {
     <div className="min-h-screen">
       <Header />
       <Hero />
+      <PartnerBar />
       <ProblemSection />
       <HowItWorks />
       <Services />

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -94,6 +94,9 @@ export const en = {
     or: 'Or, send a quick question to:',
     sticky: 'Book Free Demo'
   },
+  partners: {
+    title: 'Trusted & Supported By'
+  },
   footer: {
     blurb: "Bilingual automation for Québec SMBs. Built for today's needs, ready for tomorrow's AI.",
     language: 'Serving all of Québec • EN/FR',

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -96,6 +96,9 @@ const fr: TranslationKeys = {
     or: 'Ou, posez-moi votre question ici :',
     sticky: 'Réserver une démo'
   },
+  partners: {
+    title: 'Partenaires de confiance'
+  },
   footer: {
     blurb: "Automatisation bilingue pour PME québécoises. Conçu pour aujourd’hui, prêt pour demain.",
     language: 'Pour tout le Québec • FR/EN',

--- a/src/index.css
+++ b/src/index.css
@@ -115,6 +115,15 @@ body {
   animation: pulse-glow 3s ease-in-out infinite;
 }
 
+@keyframes scroll {
+  from { transform: translateX(0); }
+  to { transform: translateX(-50%); }
+}
+
+.animate-scroll {
+  animation: scroll 40s linear infinite;
+}
+
 /* Premium Buttons */
 .btn-primary {
   @apply inline-flex items-center justify-center px-8 py-4 text-lg font-semibold text-white rounded-xl;


### PR DESCRIPTION
## Summary
- add `PartnerBar` component with scrolling logos
- wire it up after the hero section
- add translation keys for the partner bar heading
- define scroll animation in CSS

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687e91c1297c83239e6677982698a871