### PR TITLE
Hide sticky CTA until page is scrolled

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -579,7 +579,7 @@ const FinalCTA = () => {
   });
   const [isVisible, setIsVisible] = useState(false);
   const sectionRef = useRef<HTMLElement>(null);
-  const [atTop, setAtTop] = useState(true);
+  const [heroVisible, setHeroVisible] = useState(true);
   const { t } = useLanguage();
 
   useEffect(() => {
@@ -600,14 +600,21 @@ const FinalCTA = () => {
   }, []);
 
   useEffect(() => {
-    const checkTop = () => {
-      setAtTop(window.scrollY === 0);
+    const hero = document.getElementById('hero');
+    if (!hero) return;
+
+    const checkVisibility = () => {
+      const rect = hero.getBoundingClientRect();
+      const visible = rect.bottom > 0 && rect.top < window.innerHeight;
+      setHeroVisible(visible);
     };
 
-    checkTop();
-    window.addEventListener('scroll', checkTop);
+    checkVisibility();
+    window.addEventListener('scroll', checkVisibility, { passive: true });
+    window.addEventListener('resize', checkVisibility);
     return () => {
-      window.removeEventListener('scroll', checkTop);
+      window.removeEventListener('scroll', checkVisibility);
+      window.removeEventListener('resize', checkVisibility);
     };
   }, []);
 
@@ -744,7 +751,7 @@ const FinalCTA = () => {
       </section>
 
       {/* Sticky CTA for mobile */}
-      <div className={`sticky-cta ${atTop ? 'hidden' : ''}`}>
+      <div className={`sticky-cta md:hidden ${heroVisible ? 'hidden' : 'block'}`}>
         <button className="btn-primary w-full text-lg py-4">
           {t.finalCTA.sticky}
         </button>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -579,7 +579,7 @@ const FinalCTA = () => {
   });
   const [isVisible, setIsVisible] = useState(false);
   const sectionRef = useRef<HTMLElement>(null);
-  const [heroInView, setHeroInView] = useState(true);
+  const [atTop, setAtTop] = useState(true);
   const { t } = useLanguage();
 
   useEffect(() => {
@@ -600,16 +600,15 @@ const FinalCTA = () => {
   }, []);
 
   useEffect(() => {
-    const heroElement = document.getElementById('hero');
-    if (!heroElement) return;
+    const checkTop = () => {
+      setAtTop(window.scrollY === 0);
+    };
 
-    const heroObserver = new IntersectionObserver(
-      ([entry]) => setHeroInView(entry.isIntersecting),
-      { threshold: 0 }
-    );
-
-    heroObserver.observe(heroElement);
-    return () => heroObserver.disconnect();
+    checkTop();
+    window.addEventListener('scroll', checkTop);
+    return () => {
+      window.removeEventListener('scroll', checkTop);
+    };
   }, []);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
@@ -745,7 +744,7 @@ const FinalCTA = () => {
       </section>
 
       {/* Sticky CTA for mobile */}
-      <div className={`sticky-cta ${heroInView ? 'hidden' : ''}`}>
+      <div className={`sticky-cta ${atTop ? 'hidden' : ''}`}>
         <button className="btn-primary w-full text-lg py-4">
           {t.finalCTA.sticky}
         </button>

--- a/src/index.css
+++ b/src/index.css
@@ -203,15 +203,9 @@ body {
   left: 20px;
   right: 20px;
   z-index: 50;
-  display: none;
   padding: 0 16px;
 }
 
-@media (max-width: 768px) {
-  .sticky-cta {
-    display: block;
-  }
-}
 
 /* Custom scrollbar */
 ::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- only hide sticky CTA while the page is at the very top

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e91eb32388323922d497a3fbdf15a