### PR TITLE
Add bilingual homepage copy draft

### DIFF
--- a/HOMEPAGE_COPY.md
+++ b/HOMEPAGE_COPY.md
@@ -1,0 +1,94 @@
+# Simon Paris Consulting Homepage Copy
+
+## 1. Hero Section (EN)
+**Stop drowning in admin.** Automate with peace of mind.
+Your workflow demoed before you commit—fully bilingual and compliant with Bill 96 and Law 25.
+CTA: **Show Me a Working Automation**
+
+## 1. Section Héros (FR)
+**Fini la paperasse.** Automatisez en toute tranquillité.
+Votre processus testé en démo avant engagement—bilingue et conforme à la Loi 96 et à la Loi 25.
+CTA : **Montrez-moi une automatisation en action**
+
+## 2. Pain Point Snapshot (EN)
+- No‑shows eating your schedule
+- Late invoices and cashflow headaches
+- Leads ghosting after first contact
+- Fear of Bill 96 and Law 25 fines
+
+## 2. Aperçu des problèmes (FR)
+- Trop d’absences aux rendez-vous
+- Factures en retard et problèmes de trésorerie
+- Clients potentiels qui disparaissent
+- Peur des amendes liées aux Lois 96 et 25
+
+## 3. How Simon Helps (EN)
+Simon personally builds and tests every automation so you know exactly what you’re getting. You see it running before you pay.
+- **Fewer no‑shows** with automated reminders
+- **Faster payments** thanks to invoice follow‑ups
+- **More reviews** from happy clients
+CTA: **Show Me a Working Automation**
+
+## 3. Comment Simon aide (FR)
+Simon conçoit et teste chaque automatisation lui‑même. Vous la voyez fonctionner avant de payer.
+- **Moins d’absences** grâce aux rappels automatiques
+- **Paiements plus rapides** avec les relances de factures
+- **Davantage d’avis positifs** de vos clients
+CTA : **Montrez-moi une automatisation en action**
+
+## 4. Mini-Course Promo (EN)
+**Compliance Clarity Kit** – $49–75 CAD
+Stay safe under Bill 96 and Law 25 with ready‑to‑use templates and checklists.
+CTA: **Get the Kit**
+
+## 4. Mini-Cours Promo (FR)
+**Trousse de conformité express** – 49–75 $ CAD
+Restez tranquille face aux Lois 96 et 25 grâce à des modèles et listes de vérification prêts à l’emploi.
+CTA : **Obtenir la trousse**
+
+## 5. Done‑for‑You Services (EN)
+Need it built for you? Simon handles the setup end to end, no middlemen. Every automation is demoed first and delivered fully bilingual and compliant.
+CTA: **Let’s Automate Your Admin**
+
+## 5. Service clé en main (FR)
+Besoin qu’on le fasse pour vous ? Simon s’occupe de tout, sans intermédiaire. Chaque automatisation est d’abord démontrée puis livrée bilingue et conforme.
+CTA : **Automatisons votre administration**
+
+## 6. Full Course Teaser (EN)
+**AI‑Powered Workflow Mastery** – Coming soon
+- Build automations yourself with AI helpers
+- Keep everything bilingual and compliant
+- Grow with confidence
+CTA: **Join the Waitlist**
+
+## 6. Avant-goût du cours complet (FR)
+**Maîtrise des flux de travail propulsés par l’IA** – Bientôt disponible
+- Apprenez à créer vos automatisations avec l’IA
+- Maintenez la conformité et le bilinguisme
+- Développez votre entreprise en toute confiance
+CTA : **Inscription à la liste d’attente**
+
+## 7. About Simon (EN)
+Local to Québec and fluent in both languages, Simon is a solo consultant focused on taking admin work off your plate while keeping you legally safe. No agency layers—just direct, expert help.
+
+## 7. À propos de Simon (FR)
+Installé au Québec et parfaitement bilingue, Simon est un consultant indépendant qui vous libère de l’administratif tout en assurant votre conformité. Pas d’agence, seulement un service direct et personnalisé.
+
+## 8. Trust + Compliance Checklist (EN)
+- ✅ 100% Bill 96 & Law 25 compliant
+- ✅ French‑first, bilingual by default
+- ✅ Every workflow demoed before you pay
+
+## 8. Liste de confiance et conformité (FR)
+- ✅ Conforme à 100 % aux Lois 96 et 25
+- ✅ Français d’abord, bilingue par défaut
+- ✅ Chaque flux est démontré avant paiement
+
+## 9. Final CTA (EN)
+Save time, get paid faster, and relax knowing you’re compliant.
+CTA: **Show Me a Working Automation**
+
+## 9. Appel final (FR)
+Gagnez du temps, encaissez plus vite et dormez tranquille côté conformité.
+CTA : **Montrez-moi une automatisation en action**
+


### PR DESCRIPTION
## Summary
- draft bilingual text for new homepage sections

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68892d7de4148323848e325f715bf2e6