### PR TITLE
Add bilingual privacy policy pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -998,5 +998,5 @@ function App() {
     </div>
   );
 }
-
+export { Header, Footer };
 export default App;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,23 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
+import PrivacyPolicy from './pages/PrivacyPolicy';
+import PolitiqueConfidentialite from './pages/PolitiqueConfidentialite';
 import { LanguageProvider } from './LanguageProvider';
 import './index.css';
+
+const path = window.location.pathname;
+let Component = App;
+if (path === '/privacy') {
+  Component = PrivacyPolicy;
+} else if (path === '/fr/politique-confidentialite') {
+  Component = PolitiqueConfidentialite;
+}
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <LanguageProvider>
-      <App />
+      <Component />
     </LanguageProvider>
-  </StrictMode>
+  </StrictMode>,
 );

--- a/src/pages/PolitiqueConfidentialite.tsx
+++ b/src/pages/PolitiqueConfidentialite.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { Header, Footer } from '../App';
+
+const PolitiqueConfidentialite = () => {
+  return (
+    <div className="min-h-screen bg-white">
+      <Header />
+      <div className="fixed top-4 right-4 z-50">
+        <a href="/privacy" className="text-[#2ED3CF] hover:text-[#2280FF] font-semibold">EN</a>
+      </div>
+      <main className="max-w-[800px] mx-auto p-8 pt-32">
+        <h1 className="text-3xl font-bold mb-6">Politique de confidentialité (Loi 25 &amp; LCAPC)</h1>
+        <p className="mb-6">
+          Bienvenue chez Simon Paris Consulting. Nous respectons votre vie privée et nous engageons à protéger vos renseignements personnels conformément à la Loi 25 du Québec et à la Loi canadienne anti-pourriel (LCAPC). Cette politique décrit comment nous collectons, utilisons, divulguons et sécurisons vos données.
+        </p>
+
+        <h2 className="text-2xl font-semibold text-[#2ED3CF] mb-4">1. Responsable</h2>
+        <p className="mb-6">
+          <strong>Responsable:</strong> Simon Paris (entrepreneur individuel)<br />
+          <strong>Adresse:</strong> 1234 Rue Exemple, Québec (QC) G1A 0A0<br />
+          <strong>Courriel:</strong> <a href="mailto:privacy@simonparis.ca" className="text-[#2ED3CF] hover:text-[#2280FF]">privacy@simonparis.ca</a>
+        </p>
+
+        <h2 className="text-2xl font-semibold text-[#2ED3CF] mb-4">2. Données collectées</h2>
+        <table className="w-full border-collapse mb-6">
+          <thead>
+            <tr>
+              <th className="border px-4 py-2 text-left">Élément</th>
+              <th className="border px-4 py-2 text-left">Source</th>
+              <th className="border px-4 py-2 text-left">Finalité</th>
+              <th className="border px-4 py-2 text-left">Base légale</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td className="border px-4 py-2">Prénom</td>
+              <td className="border px-4 py-2">Formulaire</td>
+              <td className="border px-4 py-2">Personnalisation, contacts</td>
+              <td className="border px-4 py-2">Consentement</td>
+            </tr>
+            <tr>
+              <td className="border px-4 py-2">Courriel</td>
+              <td className="border px-4 py-2">Formulaire</td>
+              <td className="border px-4 py-2">Infolettre, mises à jour</td>
+              <td className="border px-4 py-2">Consentement</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h2 className="text-2xl font-semibold text-[#2ED3CF] mb-4">3. Stockage &amp; Sécurité</h2>
+        <ul className="list-disc list-inside mb-6">
+          <li><strong>Emplacements :</strong> Systeme.io, Airtable (chiffré au repos)</li>
+          <li><strong>Accès :</strong> Simon Paris, assistant, CRM</li>
+          <li><strong>Sécurité :</strong> HTTPS, mots de passe forts, révisions d’accès</li>
+        </ul>
+
+        <h2 className="text-2xl font-semibold text-[#2ED3CF] mb-4">4. Conservation &amp; Suppression</h2>
+        <p className="mb-6">
+          <strong>Durée :</strong> 24 mois après dernière interaction.<br />
+          <strong>Suppression :</strong> Destruction sécurisée selon notre registre.
+        </p>
+
+        <h2 className="text-2xl font-semibold text-[#2ED3CF] mb-4">5. Vos Droits</h2>
+        <p className="mb-6">
+          Vous pouvez accéder, corriger ou effacer vos données à tout moment. Pour exercer vos droits : <a href="mailto:privacy@simonparis.ca" className="text-[#2ED3CF] hover:text-[#2280FF]">privacy@simonparis.ca</a>. Vous pouvez aussi déposer une plainte auprès de la CAI QC.
+        </p>
+
+        <h2 className="text-2xl font-semibold text-[#2ED3CF] mb-4">6. Cookies &amp; Suivi</h2>
+        <p className="mb-6">Nous utilisons uniquement des cookies essentiels après consentement. Aucun cookie marketing ou analytique ne s’active avant.</p>
+
+        <h2 className="text-2xl font-semibold text-[#2ED3CF] mb-4">7. Partage à des tiers</h2>
+        <p className="mb-6">Données partagées uniquement avec systeme.io et Airtable sous ententes conformes à la Loi 25.</p>
+
+        <h2 className="text-2xl font-semibold text-[#2ED3CF] mb-4">8. Modifications</h2>
+        <p>Dernière mise à jour : 5 août 2025. Nous vous informerons par courriel en cas de changement important.</p>
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default PolitiqueConfidentialite;

--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { Header, Footer } from '../App';
+
+const PrivacyPolicy = () => {
+  return (
+    <div className="min-h-screen bg-white">
+      <Header />
+      <div className="fixed top-4 right-4 z-50">
+        <a href="/fr/politique-confidentialite" className="text-[#2ED3CF] hover:text-[#2280FF] font-semibold">FR</a>
+      </div>
+      <main className="max-w-[800px] mx-auto p-8 pt-32">
+        <h1 className="text-3xl font-bold mb-6">Privacy Policy (Law 25 &amp; CASL Compliance)</h1>
+        <p className="mb-6">
+          Welcome to Simon Paris Consulting. We respect your privacy and are committed to protecting your personal information under Quebec’s Law 25 and Canada’s Anti-Spam Legislation (CASL). This policy explains how we collect, use, disclose, and safeguard your data.
+        </p>
+
+        <h2 className="text-2xl font-semibold text-[#2ED3CF] mb-4">1. Data Controller</h2>
+        <p className="mb-6">
+          <strong>Controller:</strong> Simon Paris (sole proprietor)<br />
+          <strong>Address:</strong> 1234 Rue Exemple, Québec (QC) G1A 0A0<br />
+          <strong>Email:</strong> <a href="mailto:privacy@simonparis.ca" className="text-[#2ED3CF] hover:text-[#2280FF]">privacy@simonparis.ca</a>
+        </p>
+
+        <h2 className="text-2xl font-semibold text-[#2ED3CF] mb-4">2. Personal Data We Collect</h2>
+        <table className="w-full border-collapse mb-6">
+          <thead>
+            <tr>
+              <th className="border px-4 py-2 text-left">Data Element</th>
+              <th className="border px-4 py-2 text-left">Source</th>
+              <th className="border px-4 py-2 text-left">Purpose</th>
+              <th className="border px-4 py-2 text-left">Legal Basis</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td className="border px-4 py-2">First Name</td>
+              <td className="border px-4 py-2">Opt-in form</td>
+              <td className="border px-4 py-2">Personalization, outreach</td>
+              <td className="border px-4 py-2">Consent</td>
+            </tr>
+            <tr>
+              <td className="border px-4 py-2">Email</td>
+              <td className="border px-4 py-2">Opt-in form</td>
+              <td className="border px-4 py-2">Newsletter, updates</td>
+              <td className="border px-4 py-2">Consent</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h2 className="text-2xl font-semibold text-[#2ED3CF] mb-4">3. Storage &amp; Security</h2>
+        <ul className="list-disc list-inside mb-6">
+          <li><strong>Locations:</strong> Systeme.io, Airtable (encrypted at rest)</li>
+          <li><strong>Access:</strong> Simon Paris, designated assistant, CRM</li>
+          <li><strong>Security:</strong> HTTPS, strong passwords, periodic access reviews</li>
+        </ul>
+
+        <h2 className="text-2xl font-semibold text-[#2ED3CF] mb-4">4. Retention &amp; Destruction</h2>
+        <p className="mb-6">
+          <strong>Retention period:</strong> 24 months from last interaction.<br />
+          <strong>Destruction:</strong> Secure deletion logged in our register.
+        </p>
+
+        <h2 className="text-2xl font-semibold text-[#2ED3CF] mb-4">5. Your Rights</h2>
+        <p className="mb-6">
+          You may request to access, correct, or erase your data at any time. To exercise your rights, contact <a href="mailto:privacy@simonparis.ca" className="text-[#2ED3CF] hover:text-[#2280FF]">privacy@simonparis.ca</a>. You may also file a complaint with the Commission d’accès à l’information du Québec.
+        </p>
+
+        <h2 className="text-2xl font-semibold text-[#2ED3CF] mb-4">6. Cookies &amp; Tracking</h2>
+        <p className="mb-6">We use only essential cookies after consent. No marketing or analytics cookies fire before opt-in.</p>
+
+        <h2 className="text-2xl font-semibold text-[#2ED3CF] mb-4">7. Third-Party Sharing</h2>
+        <p className="mb-6">We share data only with systeme.io and Airtable under Law 25-equivalent agreements.</p>
+
+        <h2 className="text-2xl font-semibold text-[#2ED3CF] mb-4">8. Changes to this Policy</h2>
+        <p>Last updated: August 5, 2025. We will email you if there’s a material change.</p>
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default PrivacyPolicy;


### PR DESCRIPTION
## Summary
- Add standalone English `/privacy` and French `/fr/politique-confidentialite` policy pages with accent styling and sticky language toggle
- Export header and footer and render correct page based on URL path

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688fc9474fd083239ae7de17b88e1baf