### PR TITLE
feat: add French site with language routing

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="alternate" hreflang="en" href="/index.html" />
+    <link rel="alternate" hreflang="fr" href="/fr/index.html" />
+    <title>Simon Paris Consulting | Automatisation bilingue pour les entreprises du Québec</title>
+    <meta name="description" content="Automatisez vos suivis, avis et rappels. Automatisation 100% bilingue et conforme à la Loi 96 pour les cliniques, métiers et entreprises de bien-être du Québec." />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="../src/main.tsx"></script>
+  </body>
+</html>
+

--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="alternate" hreflang="en" href="/index.html" />
+    <link rel="alternate" hreflang="fr" href="/fr/index.html" />
     <title>Simon Paris Consulting | Bilingual Automation for Québec Businesses</title>
     <meta name="description" content="Automate your follow-ups, reviews & reminders. 100% bilingual & Bill 96 compliant automation for Québec clinics, trades, and wellness businesses." />
   </head>

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,3 @@
+/fr/* /fr/index.html 200
 /* /index.html 200
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,24 +29,34 @@ const Header = ({ langToggleHref, langToggleLabel }: { langToggleHref?: string; 
   const textClass = !isScrolled && isPrivacyPage ? 'text-[#121C2D]' : 'text-white';
 
   const LanguageToggle = () => {
+    const targetLang = lang === 'en' ? 'fr' : 'en';
+    const href = targetLang === 'fr' ? '/fr' : '/';
     if (langToggleHref && langToggleLabel) {
       return (
         <a
           href={langToggleHref}
           className={`${textClass} underline decoration-transparent hover:decoration-[#2280FF]`}
+          onClick={() => {
+            setLang(targetLang);
+            localStorage.setItem('lang', targetLang);
+          }}
         >
           {langToggleLabel}
         </a>
       );
     }
     return (
-      <button
+      <a
+        href={href}
         className={`flex items-center text-sm ${textClass} underline decoration-transparent hover:decoration-[#2280FF]`}
-        onClick={() => setLang(lang === 'en' ? 'fr' : 'en')}
+        onClick={() => {
+          setLang(targetLang);
+          localStorage.setItem('lang', targetLang);
+        }}
       >
         <Globe className="w-4 h-4 mr-2" />
         <span>{t.header.languageToggle}</span>
-      </button>
+      </a>
     );
   };
 

--- a/src/LanguageProvider.tsx
+++ b/src/LanguageProvider.tsx
@@ -35,9 +35,17 @@ const detectLanguage = async (): Promise<Language> => {
 };
 
 export const LanguageProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [lang, setLang] = useState<Language>('en');
+  const pathLang =
+    typeof window !== 'undefined' && window.location.pathname.startsWith('/fr') ? 'fr' : 'en';
+  const [lang, setLang] = useState<Language>(pathLang);
 
   useEffect(() => {
+    const currentPathLang = window.location.pathname.startsWith('/fr') ? 'fr' : null;
+    if (currentPathLang) {
+      setLang(currentPathLang);
+      localStorage.setItem('lang', currentPathLang);
+      return;
+    }
     const stored = localStorage.getItem('lang') as Language | null;
     if (stored) {
       setLang(stored);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,19 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
   optimizeDeps: {
     exclude: ['lucide-react'],
+  },
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        fr: resolve(__dirname, 'fr/index.html'),
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary
- add French index with localized meta tags and hreflang references
- update language provider and toggle to honor /fr URL
- configure build and redirects for French routes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890159f7c6c832380d8b63fd3250133