### PR TITLE
feat: refresh hero with bilingual compliance copy

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -150,56 +150,57 @@ const Header = ({ langToggleHref, langToggleLabel }: { langToggleHref?: string; 
 
 // Hero Component
 const Hero = () => {
-  const [isVisible, setIsVisible] = useState(false);
   const { t } = useLanguage();
-
-  useEffect(() => {
-    setIsVisible(true);
-  }, []);
+  const isFR = typeof window !== 'undefined' && window.location.pathname.startsWith('/fr');
+  const base = isFR ? '/fr' : '';
 
   return (
-    <section id="hero" className="relative min-h-screen flex items-center justify-center overflow-hidden" style={{ background: '#121C2D' }}>
+    <section
+      id="hero"
+      className="relative min-h-screen flex items-center justify-center overflow-hidden"
+      style={{ background: '#121C2D' }}
+    >
       {/* Animated background elements */}
       <div className="absolute inset-0">
         <div className="absolute top-20 left-10 w-72 h-72 bg-blue-500/10 rounded-full blur-3xl animate-float" />
-        <div className="absolute bottom-20 right-10 w-96 h-96 bg-teal-400/10 rounded-full blur-3xl animate-float" style={{ animationDelay: '2s' }} />
+        <div
+          className="absolute bottom-20 right-10 w-96 h-96 bg-teal-400/10 rounded-full blur-3xl animate-float"
+          style={{ animationDelay: '2s' }}
+        />
       </div>
 
       <div className="relative z-10 max-w-6xl mx-auto px-6 lg:px-8 text-center">
-        <div className={`transition-all duration-1000 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}>
-          <div className="inline-flex items-center card-glass rounded-full px-4 py-2 mb-8">
-            <Sparkles className="w-4 h-4 mr-2 text-teal-400" />
-            <span className="text-sm font-medium text-white">{t.hero.tagline}</span>
-          </div>
-          
-          <h1 className="text-hero text-white mb-6">
-            {t.hero.heading}
-            <span className="text-teal-400">{t.hero.highlight}</span>
-          </h1>
-          
-          <p className="text-lg text-gray-400 mb-4 max-w-2xl mx-auto">
-            {t.hero.sub1}
-          </p>
-          
-          <p className="text-subhead max-w-3xl mx-auto mb-12 text-gray-300">
-            {t.hero.sub2}
-          </p>
-          
-          <div className="flex flex-col sm:flex-row gap-4 justify-center items-center mb-6">
-            <button className="btn-primary text-xl px-10 py-5 group">
-              <Calendar className="w-6 h-6 mr-3" />
-              {t.hero.bookDemo}
-              <ArrowRight className="w-6 h-6 ml-3 group-hover:translate-x-1 transition-transform group-hover:text-teal-400" />
-            </button>
-          </div>
-
-          <p className="text-sm font-medium flex justify-center items-center text-[#2280FF] mb-8">
-            <CheckCircle className="w-4 h-4 mr-2 text-teal-400" />
-            {t.trustBadge}
-          </p>
-
-          <div className="w-16 h-1 bg-teal-400 rounded-full mx-auto" />
+        <div className="inline-flex items-center card-glass rounded-full px-4 py-2 mb-8">
+          <span className="text-sm font-medium text-white">{t.hero.eyebrow}</span>
         </div>
+
+        <h1 className="text-hero text-white mb-6 leading-tight tracking-tight">
+          <span>{t.hero.h1_part1} </span>
+          <span className="text-[#139E9B]">{t.hero.h1_accent}</span>
+        </h1>
+
+        <p className="text-subhead !text-white/90 max-w-3xl mx-auto mb-4">{t.hero.subhead}</p>
+        <p className="text-sm !text-white/70 mb-10">{t.hero.proof}</p>
+
+        <div className="flex flex-col sm:flex-row gap-3 justify-center items-center">
+          <a
+            href={`${base}/checklist`}
+            className="btn-primary text-lg px-8 py-4"
+            data-event="cta_click"
+            data-cta="checklist"
+          >
+            {t.hero.primaryCta}
+          </a>
+          <a
+            href={`${base}/packs`}
+            className="btn-outline text-lg px-8 py-4"
+            data-event="cta_click"
+            data-cta="packs"
+          >
+            {t.hero.secondaryCta}
+          </a>
+        </div>
+
       </div>
     </section>
   );

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -6,14 +6,16 @@ export const en = {
     bookDemo: 'Book Demo'
   },
   hero: {
-    tagline: 'Built for Québec clinics, trades, and wellness businesses.',
-    heading: 'Stop losing clients to',
-    highlight: ' admin chaos',
-    sub1: 'Automate your reminders, follow-ups, and reviews—bilingually, legally, and without lifting a finger.',
-    sub2: 'Bill 96 + Law 25 safe. Demo before you decide.',
-    bookDemo: 'Show Me a Working Automation',
-    quickQuestion: 'Quick Question?'
-  },
+    eyebrow: 'For Québec clinics • Law 25 + Bill 96 ready',
+    h1_part1: 'Fill Your Schedule.',
+    h1_accent: 'Stay 100% Compliant.',
+    subhead:
+      'Plug‑and‑play bilingual automations for Speed‑to‑Lead, No‑Show Chaser, and Review Engine—built for Québec clinics. Demo first. Install in minutes.',
+      proof:
+        'Clinics that automate often see 25–50% fewer no‑shows and much faster follow‑ups.',
+      primaryCta: 'Get Free Compliance Checklist',
+      secondaryCta: 'See Automation Packs ($149)'
+    },
   problems: {
     heading: 'Does this sound',
     highlight: ' familiar?',

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -8,14 +8,16 @@ const fr: TranslationKeys = {
     bookDemo: 'Réserver une démo'
   },
   hero: {
-    tagline: 'Pensé pour les PME du Québec',
-    heading: 'Dites adieu aux',
-    highlight: ' absences, suivis oubliés et factures impayées.',
-    sub1: 'J\u2019automatise vos rappels, suivis et demandes d\u2019avis\u2014en français, conforme aux lois du Québec, et sans effort.',
-    sub2: 'Conforme aux lois 25 et 96 \u2022 Français en priorité \u2022 Démo avant engagement',
-    bookDemo: 'Voir une automatisation en action',
-    quickQuestion: 'Une question rapide ?'
-  },
+    eyebrow: 'Pour les cliniques du Québec • Prêt Loi 25 + Loi 96',
+    h1_part1: 'Remplissez votre horaire.',
+    h1_accent: 'Restez 100 % conforme.',
+    subhead:
+      "Automatisations bilingues prêtes à l’emploi pour réponse instantanée aux demandes (Speed‑to‑Lead), relance des absents et moteur d’avis—conçues pour les cliniques du Québec. Démo avant d’acheter. Installation en quelques minutes.",
+      proof:
+        'Les cliniques constatent souvent 25–50 % moins d’absences et des suivis beaucoup plus rapides.',
+      primaryCta: 'Télécharger la liste de conformité',
+      secondaryCta: 'Voir les packs d’automatisation (149 $)'
+    },
   problems: {
     heading: 'Vous reconnaissez ces',
     highlight: ' situations?',


### PR DESCRIPTION
## Summary
- update hero copy and translations for new scheduling/compliance messaging
- enforce high-contrast subhead and proof text in hero
- remove micro-trust line per scope

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a488135da4832385a1386097c15df6