### PR TITLE
Revamp body sections with new offers and ROI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,10 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useLanguage } from './LanguageProvider';
-import { 
-  Globe, Menu, X, Send, Calendar, ArrowRight, Sparkles,
-  Users, Clock, Star, Shield, CheckCircle, Zap, Target, Award,
-  ChevronDown, ChevronUp, MessageSquare, TrendingUp, AlertTriangle,
-  Mail, MapPin, BookOpenCheck, GraduationCap
+import {
+  Globe, Menu, X,
+  MessageSquare, CalendarX, Receipt, Shield,
+  Zap, CalendarCheck, Star, CheckCircle,
+  Mail, MapPin
 } from 'lucide-react';
 
 // Header Component
@@ -290,22 +290,16 @@ const ProblemSection = () => {
 
   const problems = t.problems.list.map((p, i) => ({
     ...p,
-    icon: [MessageSquare, Clock, Star, AlertTriangle][i]
+    icon: [MessageSquare, CalendarX, Receipt, Shield][i]
   }));
 
   return (
     <section id="automations" ref={sectionRef} className="relative py-16 lg:py-20 overflow-hidden" style={{ background: '#FFFFFF' }}>
       <div className="relative z-10 max-w-7xl mx-auto px-6 lg:px-8">
         <div className={`text-center mb-16 transition-all duration-1000 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}>
-          <h2 className="text-display text-gray-900 mb-6">
-            {t.problems.heading}
-            <span className="text-teal-400">{t.problems.highlight}</span>
-          </h2>
-          <p className="text-subhead max-w-3xl mx-auto text-gray-600">
-            {t.problems.subheading}
-          </p>
+          <h2 className="text-display text-gray-900 mb-6">{t.problems.title}</h2>
         </div>
-        
+
         <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6 lg:gap-8">
           {problems.map((problem, index) => (
             <div
@@ -318,28 +312,26 @@ const ProblemSection = () => {
               <div className="w-16 h-16 rounded-2xl bg-[#2280FF]/20 flex items-center justify-center mx-auto mb-6 group-hover:scale-110 transition-transform duration-300">
                 <problem.icon className="w-8 h-8 text-[#2280FF]" />
               </div>
-              
+
               <h3 className="text-lg lg:text-xl font-semibold text-gray-900 mb-3">
                 {problem.title}
               </h3>
-              
-              <p className="text-gray-600 mb-4 leading-relaxed text-sm lg:text-base">
-                {problem.description}
+
+              <p className="text-gray-600 leading-relaxed text-sm lg:text-base">
+                {problem.body}
               </p>
-              
-              <div className="inline-flex items-center px-3 py-1 rounded-full bg-[#2280FF]/10 border border-[#2280FF]/20">
-                <span className="text-[#2280FF] text-xs font-medium">{problem.impact}</span>
-              </div>
             </div>
           ))}
         </div>
+
+        <p className="text-center text-gray-600 mt-8">{t.problems.note}</p>
       </div>
     </section>
   );
 };
 
-// How It Works Component
-const HowItWorks = () => {
+// Growth Engine Component
+const GrowthEngine = () => {
   const [isVisible, setIsVisible] = useState(false);
   const sectionRef = useRef<HTMLElement>(null);
   const { t } = useLanguage();
@@ -361,61 +353,47 @@ const HowItWorks = () => {
     return () => observer.disconnect();
   }, []);
 
-  const steps = t.howItWorks.steps.map((s, i) => ({
-    ...s,
-    icon: [TrendingUp, Shield, Zap][i]
+  const gears = t.growth.gears.map((g, i) => ({
+    ...g,
+    icon: [Zap, CalendarCheck, Star][i]
   }));
 
   return (
     <section ref={sectionRef} className="relative py-16 lg:py-20 overflow-hidden" style={{ background: '#F9FAFB' }}>
       <div className="relative z-10 max-w-7xl mx-auto px-6 lg:px-8">
         <div className={`text-center mb-16 transition-all duration-1000 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}>
-          <h2 className="text-display text-gray-900 mb-6">
-            {t.howItWorks.heading}
-            <span className="text-teal-400">{t.howItWorks.highlight}</span>
-          </h2>
-          <p className="text-subhead max-w-3xl mx-auto text-gray-600">
-            {t.howItWorks.subheading}
-          </p>
+          <h2 className="text-display text-gray-900 mb-6">{t.growth.title}</h2>
         </div>
-        
+
         <div className="grid lg:grid-cols-3 gap-8">
-          {steps.map((step, index) => (
-            <div 
+          {gears.map((gear, index) => (
+            <div
               key={index}
-              className={`relative card-light p-8 text-center group transition-all duration-700 ${
+              className={`card-light p-8 text-center group transition-all duration-700 ${
                 isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'
               }`}
               style={{ transitionDelay: `${index * 200}ms` }}
             >
-              <div className="relative w-16 h-16 rounded-2xl bg-[#2280FF] flex items-center justify-center mx-auto mb-6 group-hover:scale-110 transition-transform duration-300">
-                <step.icon className="w-8 h-8 text-white" />
-                <span className="step-number">{step.number}</span>
+              <div className="w-16 h-16 rounded-2xl bg-[#2280FF] flex items-center justify-center mx-auto mb-6 group-hover:scale-110 transition-transform duration-300">
+                <gear.icon className="w-8 h-8 text-white" />
               </div>
-              
-              <h3 className="text-xl font-semibold text-gray-900 mb-4">
-                {step.title}
-              </h3>
 
-              <p className="text-gray-600 leading-relaxed">
-                {step.description}
-              </p>
-              
-              {index < steps.length - 1 && (
-                <div className="hidden lg:block absolute top-1/2 -right-4 transform -translate-y-1/2">
-                  <ArrowRight className="w-8 h-8 text-teal-400" />
-                </div>
-              )}
+              <h3 className="text-xl font-semibold text-gray-900 mb-4">{gear.title}</h3>
+              <p className="text-gray-600 leading-relaxed">{gear.desc}</p>
             </div>
           ))}
+        </div>
+
+        <div className="text-center mt-12">
+          <a href="/packs" className="btn-primary px-10 py-4">{t.growth.cta}</a>
         </div>
       </div>
     </section>
   );
 };
 
-// Services Component
-const Services = () => {
+// Offer Cards Component
+const OfferCards = () => {
   const [isVisible, setIsVisible] = useState(false);
   const sectionRef = useRef<HTMLElement>(null);
   const { t } = useLanguage();
@@ -437,121 +415,42 @@ const Services = () => {
     return () => observer.disconnect();
   }, []);
 
-  const services = t.services.list.map((s, i) => ({
-    ...s,
-    icon: [Users, Clock, Star, Shield][i]
-  }));
-
-  const benefits = t.services.benefits.map((b, i) => ({
-    ...b,
-    icon: [CheckCircle, Target, Zap][i]
-  }));
+  const offers = t.offers.list;
 
   return (
     <section ref={sectionRef} className="relative py-16 lg:py-20 overflow-hidden" style={{ background: '#FFFFFF' }}>
-      <div className="relative z-10 max-w-7xl mx-auto px-6 lg:px-8">
-        <div className={`text-center mb-16 transition-all duration-1000 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}>
-          <div className="inline-flex items-center card-glass rounded-full px-4 py-2 mb-6">
-            <Award className="w-4 h-4 mr-2 text-[#2280FF]" />
-            <span className="text-sm font-medium text-gray-900">{t.services.tagline}</span>
-          </div>
-          <h2 className="text-display text-gray-900 mb-6">
-            {t.services.heading}
-            <span className="text-teal-400">{t.services.highlight}</span>
-          </h2>
-          <p className="text-subhead max-w-3xl mx-auto text-gray-600">
-            {t.services.subheading}
-          </p>
-        </div>
-        
-        <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8 mb-16">
-          {services.map((service, index) => (
-            <div
-              key={index}
-              className={`card-light p-6 group transition-all duration-700 hover:shadow-xl hover:-translate-y-1 ${
-                isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'
-              }`}
-              style={{ transitionDelay: `${index * 150}ms` }}
-            >
-              <div className="w-16 h-16 rounded-2xl bg-[#2280FF] flex items-center justify-center mb-6 group-hover:scale-110 transition-transform duration-300">
-                <service.icon className="w-8 h-8 text-white" />
-              </div>
+      <div className="relative z-10 max-w-7xl mx-auto px-6 lg:px-8 text-center">
+        <h2 className={`text-display text-gray-900 mb-12 transition-all duration-1000 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}>{t.offers.heading}</h2>
 
-              <h3 className="text-lg font-semibold text-gray-900 mb-3">
-                {service.title}
-              </h3>
-
-              <p className="text-gray-600 mb-4 leading-relaxed text-sm">
-                {service.description}
-              </p>
-
-              <ul className="space-y-2">
-                {service.features.map((feature, featureIndex) => (
-                  <li key={featureIndex} className="flex items-center text-sm text-gray-600">
-                    <CheckCircle className="w-4 h-4 mr-2 flex-shrink-0 text-teal-400" />
-                    {feature}
-                  </li>
-                ))}
-              </ul>
+        <div className={`grid md:grid-cols-3 gap-8 transition-all duration-1000 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}>
+          {offers.map((offer, index) => (
+            <div key={index} className="card-light p-8 flex flex-col">
+              <h3 className="text-xl font-semibold text-gray-900 mb-2">{offer.title}</h3>
+              <p className="text-2xl font-bold text-gray-900 mb-4">{offer.price}</p>
+              <p className="text-gray-600 mb-6 flex-1">{offer.desc}</p>
+              <a href={offer.href} className="btn-primary mt-auto">{offer.cta}</a>
             </div>
           ))}
         </div>
-        
-        <div id="why-simon" className={`transition-all duration-1000 delay-600 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}>
-          <div className="card-light p-12 relative overflow-hidden">
-            <div className="relative z-10">
-              <h3 className="text-2xl lg:text-3xl font-bold text-gray-900 text-center mb-12">
-                {t.services.whyTitle}
-              </h3>
-              
-              <div className="grid md:grid-cols-3 gap-8">
-                {benefits.map((benefit, index) => (
-                  <div key={index} className="text-center group">
-                    <div className="w-20 h-20 rounded-2xl bg-[#2280FF] flex items-center justify-center mx-auto mb-6 group-hover:scale-110 transition-transform duration-300">
-                      <benefit.icon className="w-10 h-10 text-white" />
-                    </div>
-                    <h4 className="text-xl font-semibold text-gray-900 mb-3">
-                      {benefit.title}
-                    </h4>
-                    <p className="text-gray-600 leading-relaxed">
-                      {benefit.description}
-                    </p>
-                  </div>
-                ))}
-              </div>
-              
-              <div className="text-center mt-12">
-                <button className="btn-primary px-10 py-4">
-                  {t.services.startJourney}
-                </button>
-                
-                <p className="text-gray-600 mt-6 max-w-2xl mx-auto leading-relaxed">
-                  {t.services.whyParagraph}
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
+
+        <p className="text-gray-600 mt-6">{t.offers.note}</p>
       </div>
     </section>
   );
 };
 
-// Courses Section Component
-const Courses = () => {
+// ROI Math Component
+const ROIMath = () => {
   const [isVisible, setIsVisible] = useState(false);
   const sectionRef = useRef<HTMLElement>(null);
-  const { t } = useLanguage();
+  const { t, lang } = useLanguage();
 
   useEffect(() => {
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          setIsVisible(true);
-        }
-      },
-      { threshold: 0.3 }
-    );
+    const observer = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting) {
+        setIsVisible(true);
+      }
+    }, { threshold: 0.3 });
 
     if (sectionRef.current) {
       observer.observe(sectionRef.current);
@@ -561,64 +460,24 @@ const Courses = () => {
   }, []);
 
   return (
-    <section
-      id="courses"
-      ref={sectionRef}
-      className="relative py-20 lg:py-24 overflow-hidden mt-16"
-      style={{ background: '#F9FAFB' }}
-    >
-      <div className="relative z-10 max-w-7xl mx-auto px-6 lg:px-8">
-        <div className={`text-center mb-12 transition-all duration-1000 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}> 
-          <h2 className="text-display text-gray-900 mb-4">{t.courses.title}</h2>
-          <p className="text-subhead text-gray-600">{t.courses.subheading}</p>
+    <section ref={sectionRef} className="relative py-16 lg:py-20 overflow-hidden" style={{ background: '#F9FAFB' }}>
+      <div className="relative z-10 max-w-5xl mx-auto px-6 lg:px-8 text-center">
+        <div className={`mb-12 transition-all duration-1000 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}>
+          <h2 className="text-display text-gray-900 mb-6">{t.roi.title}</h2>
         </div>
-        <div
-          className={`grid md:grid-cols-2 gap-8 transition-all duration-1000 ${
-            isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'
-          }`}
-        >
-          <div className="card-light p-8 hover:shadow-xl hover:-translate-y-1 transition-all">
-            <div className="w-16 h-16 rounded-2xl bg-[#2280FF] flex items-center justify-center mx-auto mb-6">
-              <BookOpenCheck className="w-8 h-8 text-white" />
-            </div>
-            <h3 className="text-xl font-semibold text-gray-900 mb-4 text-center">
-              {t.miniCourse.heading}
-            </h3>
-            <p className="text-gray-600 mb-6 text-center">{t.miniCourse.subheading}</p>
-            <ul className="space-y-2 mb-6">
-              {t.miniCourse.list.map((item: string, idx: number) => (
-                <li key={idx} className="flex items-center text-gray-600">
-                  <CheckCircle className="w-4 h-4 mr-2 text-teal-400" />
-                  {item}
-                </li>
-              ))}
-            </ul>
-            <div className="text-center">
-              <button className="btn-primary px-8 py-4">{t.miniCourse.cta}</button>
-            </div>
-          </div>
 
-          <div className="card-light p-8 hover:shadow-xl hover:-translate-y-1 transition-all">
-            <div className="w-16 h-16 rounded-2xl bg-[#2280FF] flex items-center justify-center mx-auto mb-6">
-              <GraduationCap className="w-8 h-8 text-white" />
-            </div>
-            <h3 className="text-xl font-semibold text-gray-900 mb-4 text-center">
-              {t.fullCourse.heading}
-            </h3>
-            <p className="text-gray-600 mb-6 text-center">{t.fullCourse.subheading}</p>
-            <ul className="space-y-2 mb-6">
-              {t.fullCourse.list.map((item: string, idx: number) => (
-                <li key={idx} className="flex items-center text-gray-600">
-                  <CheckCircle className="w-4 h-4 mr-2 text-teal-400" />
-                  {item}
-                </li>
-              ))}
-            </ul>
-            <div className="text-center">
-              <button className="btn-primary px-8 py-4">{t.fullCourse.cta}</button>
-            </div>
+        <div className={`grid md:grid-cols-2 gap-8 transition-all duration-1000 delay-200 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}>
+          <div className="card-light p-8">
+            <h3 className="text-xl font-semibold text-gray-900 mb-2">{lang === 'fr' ? 'Sans automatisation' : 'Without automation'}</h3>
+            <p className="text-gray-600">{t.roi.without}</p>
+          </div>
+          <div className="card-light p-8">
+            <h3 className="text-xl font-semibold text-gray-900 mb-2">{lang === 'fr' ? 'Avec automatisation' : 'With automation'}</h3>
+            <p className="text-gray-600">{t.roi.with}</p>
           </div>
         </div>
+
+        <p className="text-gray-600 mt-8">{t.roi.note}</p>
       </div>
     </section>
   );
@@ -631,14 +490,11 @@ const ProofSection = () => {
   const { t } = useLanguage();
 
   useEffect(() => {
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          setIsVisible(true);
-        }
-      },
-      { threshold: 0.3 }
-    );
+    const observer = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting) {
+        setIsVisible(true);
+      }
+    }, { threshold: 0.3 });
 
     if (sectionRef.current) {
       observer.observe(sectionRef.current);
@@ -648,48 +504,26 @@ const ProofSection = () => {
   }, []);
 
   return (
-    <section ref={sectionRef} className="relative py-20 overflow-hidden" style={{ background: '#F9FAFB' }}>
+    <section ref={sectionRef} className="relative py-16 lg:py-20 overflow-hidden" style={{ background: '#FFFFFF' }}>
       <div className="relative z-10 max-w-7xl mx-auto px-6 lg:px-8">
-        <div className={`text-center mb-16 transition-all duration-1000 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}>
-          <h2 className="text-display text-gray-900 mb-6">
-            {t.proof.heading}
-            <span className="text-teal-400">{t.proof.highlight}</span>
-          </h2>
-          <p className="text-subhead max-w-3xl mx-auto text-gray-600">
-            {t.proof.subheading}
-          </p>
+        <div className={`text-center mb-12 transition-all duration-1000 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}>
+          <h2 className="text-display text-gray-900 mb-6">{t.proof.title}</h2>
         </div>
-        
-        <div className={`transition-all duration-1000 delay-300 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}>
-          <div className="card-light p-12 text-center">
-            <div className="max-w-3xl mx-auto">
-              <div className="w-20 h-20 rounded-2xl bg-[#2280FF] flex items-center justify-center mx-auto mb-8">
-                <Shield className="w-10 h-10 text-white" />
-              </div>
-              
-              <h3 className="text-2xl font-bold text-gray-900 mb-6">
-                {t.proof.calloutHeading}
-              </h3>
-              
-              <p className="text-lg text-gray-600 mb-8 leading-relaxed">
-                {t.proof.calloutText}
-              </p>
-              
-              <div className="grid md:grid-cols-3 gap-8 mb-8">
-                {t.proof.items.map((label, i) => (
-                  <div key={`stat-${i}`} className="text-center">
-                    <div className="text-3xl font-bold text-[#2280FF] mb-2">{['100%', '24/7', 'EN/FR'][i]}</div>
-                    <div className="text-gray-600">{label}</div>
-                  </div>
-                ))}
-              </div>
-              
-              <button className="btn-primary px-8 py-4">
-                {t.proof.button}
-              </button>
-            </div>
-          </div>
+
+        <div className={`grid md:grid-cols-3 gap-8 mb-12 transition-all duration-1000 delay-200 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}>
+          {[0, 1, 2].map(i => (
+            <div key={i} className="card-light h-40 flex items-center justify-center text-gray-400">Placeholder</div>
+          ))}
         </div>
+
+        <ul className={`max-w-3xl mx-auto space-y-4 text-gray-600 transition-all duration-1000 delay-400 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}>
+          {t.proof.bullets.map((bullet, index) => (
+            <li key={index} className="flex items-start">
+              <CheckCircle className="w-5 h-5 text-[#2280FF] mr-2 mt-1" />
+              <span>{bullet}</span>
+            </li>
+          ))}
+        </ul>
       </div>
     </section>
   );
@@ -725,13 +559,7 @@ const FAQ = () => {
     <section ref={sectionRef} className="relative py-12 lg:py-20 overflow-hidden" style={{ background: '#FFFFFF' }}>
       <div className="relative z-10 max-w-4xl mx-auto px-6 lg:px-8">
         <div className={`text-center mb-16 transition-all duration-1000 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}>
-          <h2 className="text-display text-gray-900 mb-6">
-            {t.faq.heading}
-            <span className="text-teal-400">{t.faq.highlight}</span>
-          </h2>
-          <p className="text-subhead text-gray-600">
-            {t.faq.subheading}
-          </p>
+          <h2 className="text-display text-gray-900 mb-6">{t.faq.title}</h2>
         </div>
         
         <div className={`space-y-4 transition-all duration-1000 delay-300 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}>
@@ -770,196 +598,23 @@ const FAQ = () => {
 
 // Final CTA Component
 const FinalCTA = () => {
-  const [formData, setFormData] = useState({
-    name: '',
-    email: '',
-    businessType: '',
-    painPoint: ''
-  });
-  const [isVisible, setIsVisible] = useState(false);
-  const sectionRef = useRef<HTMLElement>(null);
-  const [heroVisible, setHeroVisible] = useState(true);
   const { t } = useLanguage();
 
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          setIsVisible(true);
-        }
-      },
-      { threshold: 0.3 }
-    );
-
-    if (sectionRef.current) {
-      observer.observe(sectionRef.current);
-    }
-
-    return () => observer.disconnect();
-  }, []);
-
-  useEffect(() => {
-    const hero = document.getElementById('hero');
-    if (!hero) return;
-
-    const checkVisibility = () => {
-      const rect = hero.getBoundingClientRect();
-      const visible = rect.bottom > 0 && rect.top < window.innerHeight;
-      setHeroVisible(visible);
-    };
-
-    checkVisibility();
-    window.addEventListener('scroll', checkVisibility, { passive: true });
-    window.addEventListener('resize', checkVisibility);
-    return () => {
-      window.removeEventListener('scroll', checkVisibility);
-      window.removeEventListener('resize', checkVisibility);
-    };
-  }, []);
-
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
-    setFormData({
-      ...formData,
-      [e.target.name]: e.target.value
-    });
-  };
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    console.log('Form submitted:', formData);
-  };
-
   return (
-    <>
-      <section ref={sectionRef} className="relative py-20 overflow-hidden" style={{ background: '#F9FAFB' }}>
-        <div className="absolute inset-0">
-          <div className="absolute top-20 left-10 w-72 h-72 bg-teal-400/5 rounded-full blur-3xl animate-float" />
-          <div className="absolute bottom-20 right-10 w-96 h-96 bg-blue-500/5 rounded-full blur-3xl animate-float" style={{ animationDelay: '2s' }} />
+    <section className="relative py-16 bg-[#121C2D] text-center text-white">
+      <div className="max-w-4xl mx-auto px-6">
+        <h2 className="text-3xl font-bold mb-4">{t.finalCTA.title}</h2>
+        <p className="text-lg text-gray-300 mb-8">{t.finalCTA.sub}</p>
+        <div className="flex flex-col sm:flex-row gap-4 justify-center">
+          <a href={t.finalCTA.primaryHref} className="btn-primary px-8 py-4">
+            {t.finalCTA.primary}
+          </a>
+          <a href={t.finalCTA.secondaryHref} className="btn-secondary px-8 py-4">
+            {t.finalCTA.secondary}
+          </a>
         </div>
-
-        <div className="relative z-10 max-w-4xl mx-auto px-6 lg:px-8">
-          <div className={`text-center mb-12 transition-all duration-1000 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}>
-              <div className="inline-flex items-center card-glass rounded-full px-4 py-2 mb-6">
-                <Sparkles className="w-4 h-4 mr-2 text-teal-400" />
-                <span className="text-sm font-medium text-gray-900">{t.finalCTA.tagline}</span>
-              </div>
-              <h2 className="text-display text-gray-900 mb-6">
-                {t.finalCTA.heading}
-                <span className="text-teal-400">{t.finalCTA.highlight}</span>
-              </h2>
-              <p className="text-subhead text-gray-600">
-                {t.finalCTA.subheading}
-              </p>
-              <div className="mt-4 inline-flex items-center px-3 py-1 rounded-full bg-[#2280FF]/10 text-[#2280FF] text-sm font-semibold">
-                <CheckCircle className="w-4 h-4 mr-2" />
-                {t.trustBadge}
-              </div>
-          </div>
-          
-          <div className={`transition-all duration-1000 delay-300 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}>
-            <div className="card-light p-8 lg:p-12 backdrop-blur-xl">
-              <form onSubmit={handleSubmit} className="space-y-6">
-                <div className="grid md:grid-cols-2 gap-6">
-                  <div>
-                    <label htmlFor="name" className="block text-sm font-semibold text-gray-900 mb-3">
-                      {t.finalCTA.nameLabel}
-                    </label>
-                    <input
-                      type="text"
-                      id="name"
-                      name="name"
-                      required
-                      value={formData.name}
-                      onChange={handleInputChange}
-                      className="w-full px-6 py-4 bg-white border-2 border-gray-200 rounded-2xl focus:ring-4 focus:ring-teal-400/20 focus:border-teal-400 transition-all duration-300 text-lg text-gray-900"
-                      placeholder={t.finalCTA.namePlaceholder}
-                    />
-                  </div>
-                  
-                  <div>
-                    <label htmlFor="email" className="block text-sm font-semibold text-gray-900 mb-3">
-                      {t.finalCTA.emailLabel}
-                    </label>
-                    <input
-                      type="email"
-                      id="email"
-                      name="email"
-                      required
-                      value={formData.email}
-                      onChange={handleInputChange}
-                      className="w-full px-6 py-4 bg-white border-2 border-gray-200 rounded-2xl focus:ring-4 focus:ring-[#2280FF]/20 focus:border-[#2280FF] transition-all duration-300 text-lg text-gray-900"
-                      placeholder={t.finalCTA.emailPlaceholder}
-                    />
-                  </div>
-                </div>
-                
-                <div>
-                    <label htmlFor="businessType" className="block text-sm font-semibold text-gray-900 mb-3">
-                      {t.finalCTA.businessLabel}
-                    </label>
-                  <select
-                    id="businessType"
-                    name="businessType"
-                    required
-                    value={formData.businessType}
-                    onChange={handleInputChange}
-                    className="w-full px-6 py-4 bg-white border-2 border-gray-200 rounded-2xl focus:ring-4 focus:ring-[#2280FF]/20 focus:border-[#2280FF] transition-all duration-300 text-lg text-gray-900"
-                  >
-                    {t.finalCTA.businessOptions.map((o, i) => (
-                      <option key={i} value={['', 'clinic', 'wellness', 'trades', 'other'][i]}>{o}</option>
-                    ))}
-                  </select>
-                </div>
-                
-                <div>
-                    <label htmlFor="painPoint" className="block text-sm font-semibold text-gray-900 mb-3">
-                      {t.finalCTA.painLabel}
-                    </label>
-                  <textarea
-                    id="painPoint"
-                    name="painPoint"
-                    rows={4}
-                    value={formData.painPoint}
-                    onChange={handleInputChange}
-                    className="w-full px-6 py-4 bg-white border-2 border-gray-200 rounded-2xl focus:ring-4 focus:ring-[#2280FF]/20 focus:border-[#2280FF] transition-all duration-300 text-lg resize-none text-gray-900"
-                    placeholder={t.finalCTA.painPlaceholder}
-                  />
-                </div>
-                
-                <div className="pt-4">
-                  <button
-                    type="submit"
-                    className="w-full btn-primary text-xl py-6 group"
-                  >
-                    <Calendar className="w-6 h-6 mr-3" />
-                    {t.finalCTA.submit}
-                    <ArrowRight className="w-6 h-6 ml-3 group-hover:translate-x-1 group-hover:text-teal-400 transition-transform" />
-                  </button>
-                </div>
-              </form>
-              
-              <div className="mt-8 pt-8 border-t border-gray-600 text-center">
-                <p className="text-gray-600 mb-4 text-lg">{t.finalCTA.or}</p>
-                <a
-                  href={`mailto:${t.header.email}`}
-                  className="inline-flex items-center font-semibold text-lg group transition-colors duration-300 text-[#2280FF] hover:text-teal-400"
-                >
-                  <Send className="w-5 h-5 mr-2 group-hover:translate-x-1 group-hover:text-teal-400 transition-transform" />
-                  {t.header.email}
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Sticky CTA for mobile */}
-      <div className={`sticky-cta md:hidden ${heroVisible ? 'hidden' : 'block'}`}>
-        <button className="btn-primary w-full text-lg py-4">
-          {t.finalCTA.sticky}
-        </button>
       </div>
-    </>
+    </section>
   );
 };
 
@@ -1038,11 +693,11 @@ function App() {
       <Header />
       <Hero />
       <PartnerBar />
-      <ProblemSection />
-      <HowItWorks />
-      <Services />
-      <Courses />
-      <ProofSection />
+        <ProblemSection />
+        <GrowthEngine />
+        <OfferCards />
+        <ROIMath />
+        <ProofSection />
       <FAQ />
       <FinalCTA />
       <Footer />

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -17,118 +17,81 @@ export const en = {
       secondaryCta: 'See Automation Packs ($149)'
     },
   problems: {
-    heading: 'Does this sound',
-    highlight: ' familiar?',
-    subheading: 'I fix all of that—with automation that speaks French, follows the law, and actually works.',
+    title: 'Why clinics keep losing money every week…',
     list: [
-      { title: 'Ghosted Leads', description: 'Leads disappear after filling out your form', impact: 'Lost Sales' },
-      { title: 'Missed Appointments', description: 'Clients forget or arrive late', impact: 'Wasted Time' },
-      { title: 'Late Invoices', description: 'Outstanding invoices keep piling up', impact: 'Cash Flow Squeeze' },
-      { title: 'Legal Uncertainty', description: 'Unsure if your texts or emails comply with Québec law', impact: 'Risk of Fines' }
-    ]
+      { title: 'Ghosted Leads', body: 'Leads wait and book elsewhere.' },
+      { title: 'Missed Appointments', body: 'Empty chairs at prime hours.' },
+      { title: 'Late Invoices', body: 'Cash flow gets squeezed.' },
+      { title: 'Legal Uncertainty', body: 'Messaging may breach Bill 96/Law 25.' }
+    ],
+    note: 'You can fix all of this with simple, bilingual automation.'
   },
-  howItWorks: {
-    heading: 'How It Works:',
-    highlight: ' Demo First, Pay Later',
-    subheading: 'See your exact automation in action before you commit to anything',
-    steps: [
-      { number: '1', title: 'Free Demo & Audit', description: "I'll show you exactly where you're losing money and demo your custom automation live" },
-      { number: '2', title: 'Custom Setup', description: 'I build your bilingual automation workflows and ensure 100% Bill 96 compliance' },
-      { number: '3', title: 'Launch & Support', description: 'Go live with your automation and get ongoing support directly from me' }
-    ]
+  growth: {
+    title: 'Your Clinic\u2019s Growth Engine: Simple, Bilingual, Compliant.',
+    gears: [
+      { title: 'Speed\u2011to\u2011Lead SMS', desc: 'instant reply, EN/FR' },
+      { title: 'No\u2011Show Chaser + Recall', desc: 'fewer empty chairs' },
+      { title: 'Review & Compliance Engine', desc: 'more 5\u2605, audit-friendly' }
+    ],
+    cta: 'See Packs in Action'
   },
-  services: {
-    tagline: 'What I Automate',
-    heading: 'Automations that',
-    highlight: ' Save Time & Stay Compliant',
-    subheading: 'I create automations that save time, recover lost revenue, and make legal compliance effortless.',
+  offers: {
+    heading: 'Three productized paths.',
     list: [
-      { title: 'Speed to Lead', description: 'Auto-follow-up in EN/FR with every contact form, DM, or missed call', features: ['Instant response automation', 'Bilingual templates', 'Multi-channel integration'] },
-      { title: 'No-Show & Invoice Chaser', description: 'Automatic reminders, confirmations, and polite escalation sequences', features: ['Smart reminder sequences', 'Payment automation', 'Appointment confirmations'] },
-      { title: 'Review Engine', description: 'Sends smart, bilingual review requests and replies—compliance-safe, client-friendly', features: ['Automated review requests', 'Response management', 'Reputation monitoring'] },
       {
-        title: 'Loi 96 Compliance – For Your Automations',
-        description:
-          'Every message, reminder, and review request is delivered in French first, reviewed for legal clarity, and ready for inspection.',
-        features: [
-          'Language-first compliance',
-          'Bilingual message validation',
-          'Documentation available on request'
-        ]
+        title: 'DIY Packs',
+        price: '$149 each',
+        desc: 'Plug\u2011and\u2011play automations. Install in minutes.',
+        cta: 'Browse Packs',
+        href: '/packs'
+      },
+      {
+        title: 'Quick Audit',
+        price: '$249',
+        desc: '48h diagnosis + 1 quick win installed.',
+        cta: 'Book 48h Audit',
+        href: '/audit'
+      },
+      {
+        title: 'Complete System',
+        price: '$1,499',
+        desc: 'All 3 packs installed + QA + handoff.',
+        cta: 'Get the System',
+        href: '/system'
       }
     ],
-    benefits: [
-      { title: 'Demo-first', description: 'See your real-world automation in action—before you decide.' },
-      { title: 'Personal Support', description: 'Expert support—no agency handoff' },
-      { title: 'Fast ROI', description: 'Fast setup, flat pricing, visible ROI' }
-    ],
-    whyTitle: 'Why Work With Simon Paris?',
-    whyParagraph: "You'll see it work before you commit. No fluff, no guessing.",
-    startJourney: 'Show Me a Working Automation'
+    note: 'Flat pricing. No hidden fees. French-first templates.'
   },
-  miniCourse: {
-    heading: 'NEW: Understand Bill 96 & Law 25 in under an hour.',
-    subheading: 'Worried about compliance fines? This self-paced mini-course makes it simple.',
-    list: [
-      'Bilingual message templates (email, SMS, review requests)',
-      'Compliance checklists with official links',
-      'Real examples for Québec SMBs',
-      'Finish in under 60 minutes'
-    ],
-    cta: 'Explore the Compliance Kit'
-  },
-  fullCourse: {
-    heading: 'COMING SOON: AI-Powered Workflow Mastery',
-    subheading: 'Learn to automate lead capture, reminders, payments, and reviews yourself.',
-    list: [
-      'Step-by-step lessons with live demos',
-      'Bilingual templates included',
-      'Designed for Québec clinics, trades, and wellness businesses'
-    ],
-    cta: 'Join the Waitlist'
-  },
-  courses: {
-    title: 'Learn How to Automate & Stay Compliant',
-    subheading: 'Courses designed for Québec businesses who want clarity, control, and compliant growth.'
+  roi: {
+    title: '$149 vs. $900+ Lost Each Month',
+    without: '3 missed patients/month = $900+ lost.',
+    with: '$149 pack \u2192 instant replies, fewer no-shows.',
+    note: 'Most clinics recoup the pack cost in the first week.'
   },
   proof: {
-    heading: 'Built for',
-    highlight: ' Québec SMBs',
-    subheading: 'Every automation is fully demoed before you buy. Book a live walkthrough and see how it works for your business.',
-    calloutHeading: 'Bilingual automation, built in Québec for Québec SMBs',
-    calloutText: 'Tested for Bill 96 compliance—so you can sleep easy. Real results, real stories—coming soon.',
-    items: ['Bill 96 Compliant', 'Automated Follow-ups', 'Fully Bilingual'],
-    button: 'See Your Demo'
+    title: 'Clinics that automate see results fast.',
+    bullets: [
+      '25\u201350% fewer no-shows',
+      '5\u00d7 more booked appointments from instant SMS',
+      '3\u00d7 more Google reviews in 30\u201360 days'
+    ]
   },
   faq: {
-    heading: 'Frequently Asked',
-    highlight: ' Questions',
-    subheading: 'Everything you need to know about getting started',
+    title: 'FAQ',
     list: [
-      { question: 'How quickly can you set up my automation?', answer: 'Most setups are completed within 1-2 weeks after our demo call. I handle all the technical work while you focus on running your business.' },
-      { question: 'Is this really Bill 96 compliant?', answer: 'Absolutely. Every message template and automation workflow is reviewed for Bill 96 compliance. I provide documentation showing compliance for audit purposes.' },
-      { question: "What if I'm not tech-savvy?", answer: "Perfect! That's exactly who this is built for. You don't need to understand the technology—just see the results. I handle all the technical setup and maintenance." },
-      { question: 'How much does it cost?', answer: "Pricing depends on your specific needs and business size. I offer transparent, flat-rate pricing with no hidden fees. We'll discuss exact costs during your free demo." },
-      { question: 'Can you help us with AI adoption or strategy?', answer: "Absolutely. I'm always researching the latest AI tools and trends for SMBs. If you want to talk about how AI could help your business, just mention it when you book a demo." }
+      { question: 'How quickly can we launch?', answer: 'Most go live in 1\u20132 weeks after your demo.' },
+      { question: 'Is this really Bill 96/Law 25 compliant?', answer: 'Yes. French-first messaging, EN on request, and templates reviewed for clarity. Documentation available.' },
+      { question: 'Do I need to be technical?', answer: 'No. You see it working first; I handle setup and handoff.' },
+      { question: 'How much does it cost?', answer: 'DIY packs $149 each \u2022 Audit $249 \u2022 Complete system $1,499.' }
     ]
   },
   finalCTA: {
-    tagline: 'Save time, get paid faster, and relax knowing you\u2019re compliant.',
-    heading: 'Ready to Automate and',
-    highlight: ' Stay Compliant?',
-    subheading: 'See a working automation before you commit.',
-    nameLabel: 'Name *',
-    namePlaceholder: 'Your full name',
-    emailLabel: 'Email *',
-    emailPlaceholder: 'your@email.com',
-    businessLabel: 'Business Type *',
-    businessPlaceholder: 'Select your business type',
-    businessOptions: ['Select your business type', 'Medical/Dental Clinic', 'Wellness/Spa Business', 'Trades/Contractor', 'Other Service Business'],
-    painLabel: 'Your Biggest Pain Point',
-    painPlaceholder: "What's your biggest challenge with follow-ups, no-shows, or reviews?",
-    submit: 'Show Me a Working Automation',
-    or: 'Or, send a quick question to:',
-    sticky: 'Book Free Demo'
+    title: 'Start Free. Stay Compliant. Grow Faster.',
+    sub: 'Download the checklist now — upgrade to packs when ready.',
+    primary: 'Download Checklist',
+    primaryHref: '/checklist',
+    secondary: 'See Packs',
+    secondaryHref: '/packs'
   },
   trustBadge: 'Built for Québec • Demo-first • Fully bilingual & Law 96\u2013compliant',
   partners: {

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -10,125 +10,96 @@ const fr: TranslationKeys = {
   hero: {
     eyebrow: 'Pour les cliniques du Québec • Prêt Loi 25 + Loi 96',
     h1_part1: 'Remplissez votre horaire.',
-    h1_accent: 'Restez 100 % conforme.',
+    h1_accent: 'Restez 100% conforme.',
     subhead:
-      "Automatisations bilingues prêtes à l’emploi pour réponse instantanée aux demandes (Speed‑to‑Lead), relance des absents et moteur d’avis—conçues pour les cliniques du Québec. Démo avant d’acheter. Installation en quelques minutes.",
-      proof:
-        'Les cliniques constatent souvent 25–50 % moins d’absences et des suivis beaucoup plus rapides.',
-      primaryCta: 'Télécharger la liste de conformité',
-      secondaryCta: 'Voir les packs d’automatisation (149 $)'
-    },
+      'Automatisations bilingues prêtes à l’emploi pour vitesse‑à‑lead, relance d’absences et moteur d’avis — conçues pour les cliniques du Québec. Démo d’abord. Installation en minutes.',
+    proof: 'Les cliniques qui automatisent voient souvent 25–50 % moins d’absences et des suivis beaucoup plus rapides.',
+    primaryCta: 'Obtenir la checklist de conformité',
+    secondaryCta: 'Voir les packs (149 $)'
+  },
   problems: {
-    heading: 'Vous reconnaissez ces',
-    highlight: ' situations?',
-    subheading: 'Si vous g\u00e9rez une clinique, un commerce ou une entreprise de services au Qu\u00e9bec, ces probl\u00e8mes vous parlent s\u00fbr\u00e9ment\u00a0:',
+    title: 'Pourquoi les cliniques perdent de l’argent chaque semaine…',
     list: [
-      { title: 'Clients qui ne donnent plus de nouvelles', description: 'Les gens remplissent un formulaire ou vous \u00e9crivent\u2026 et disparaissent.', impact: 'Clients perdus' },
-      { title: 'Rendez-vous oubli\u00e9s ou annul\u00e9s', description: 'Des absences de derni\u00e8re minute qui nuisent \u00e0 votre horaire et vos revenus.', impact: 'Temps gaspill\u00e9' },
-      { title: 'Factures en attente', description: 'Des paiements qui tra\u00eenent, sans automatisation pour faire le suivi.', impact: 'Tr\u00e9sorerie \u00e0 risque' },
-      { title: 'Doutes sur la conformit\u00e9', description: 'Vous ne savez plus si vos messages ou rappels respectent la Loi 96.', impact: 'Risque l\u00e9gal r\u00e9el' }
-    ]
+      { title: 'Leads ignorés', body: 'Les patients attendent et réservent ailleurs.' },
+      { title: 'Rendez-vous manqués', body: 'Des chaises vides aux heures de pointe.' },
+      { title: 'Factures en retard', body: 'La trésorerie se resserre.' },
+      { title: 'Incertitude légale', body: 'Vos messages peuvent enfreindre la Loi 25/Bill 96.' }
+    ],
+    note: 'Vous pouvez tout corriger avec une simple automatisation bilingue.'
   },
-  howItWorks: {
-    heading: 'Démo d\u2019abord.',
-    highlight: ' Paiement après.',
-    subheading: 'Voyez une automatisation fonctionnelle, adaptée à votre entreprise, avant de vous engager.',
-    steps: [
-      { number: '1', title: 'Démo personnalisée gratuite', description: 'Je vous montre en direct où vous perdez temps et argent\u2014et ce qu\u2019on peut automatiser.' },
-      { number: '2', title: 'Mise en place sur mesure', description: 'Je bâtis vos automatisations en fonction de vos outils actuels, en français d\u2019abord, avec conformité totale.' },
-      { number: '3', title: 'Résultats rapides et visibles', description: 'Gain de temps, suivis automatiques, moins d\u2019oublis, plus de paiements. Concrètement.' }
-    ]
+  growth: {
+    title: 'Le moteur de croissance de votre clinique : simple, bilingue, conforme.',
+    gears: [
+      { title: 'SMS vitesse-à-lead', desc: 'réponse instantanée, FR/EN' },
+      { title: 'Poursuite d’absences + rappel', desc: 'moins de chaises vides' },
+      { title: 'Moteur d’avis et conformité', desc: 'plus de 5★, prêt pour audit' }
+    ],
+    cta: 'Voir les packs en action'
   },
-  services: {
-    tagline: 'Ce que j\u2019automatise',
-    heading: 'Des automatisations qui',
-    highlight: ' font gagner du temps et de l\u2019argent.',
-    subheading: 'Voici les processus que j\u2019automatise le plus souvent pour mes clients au Qu\u00e9bec \u00a0:',
+  offers: {
+    heading: 'Trois parcours productisés.',
     list: [
-      { title: 'Relance de prospects', description: '', features: ['Suivi automatique après formulaire, appel manqu\u00e9 ou message', 'Mod\u00e8les bilingues inclus', 'Int\u00e9gration \u00e0 vos outils (ex. Google, Meta, Square)'] },
-      { title: 'Chasseur d\u2019absences et de paiements', description: '', features: ['Rappels automatis\u00e9s avant les rendez-vous', 'Relance pour factures en retard', 'Messages FR/EN conformes et polis'] },
-      { title: 'G\u00e9n\u00e9rateur d\u2019avis clients', description: '', features: ['Envoi automatique apr\u00e8s prestation', 'Gestion des r\u00e9ponses', 'Aide au positionnement local (SEO)'] },
-        { title: 'Conformité Loi 96 – pour vos automatisations', description: "Chaque message, rappel et demande d'avis est envoyé en français d'abord, vérifié pour la clarté juridique et prêt pour inspection.", features: ['Conformité linguistique prioritaire', 'Validation bilingue des messages', 'Documentation disponible sur demande'] },
+      {
+        title: 'Packs DIY',
+        price: '149 $ chacun',
+        desc: 'Automatisations prêtes à l’emploi. Installation en minutes.',
+        cta: 'Voir les packs',
+        href: '/packs'
+      },
+      {
+        title: 'Audit rapide',
+        price: '249 $',
+        desc: 'Diagnostic en 48 h + un gain rapide installé.',
+        cta: 'Réserver l’audit 48h',
+        href: '/audit'
+      },
+      {
+        title: 'Système complet',
+        price: '1 499 $',
+        desc: 'Les 3 packs installés + QA + transfert.',
+        cta: 'Obtenir le système',
+        href: '/system'
+      }
     ],
-    benefits: [
-      { title: 'Démo en direct', description: 'Voyez votre automatisation réelle en action—avant de vous décider.' },
-      { title: 'Support personnalis\u00e9', description: 'Vous travaillez avec moi, pas avec un repr\u00e9sentant ou une agence.' },
-      { title: 'R\u00e9sultats concrets', description: 'Moins de gestion. Moins d\u2019oublis. Plus de revenus.' }
-    ],
-    whyTitle: 'Pourquoi choisir Simon Paris ?',
-    whyParagraph: 'Vous verrez le tout fonctionner avant de vous engager. Aucun bla-bla, aucune surprise.',
-    startJourney: 'Voir une automatisation en action'
+    note: 'Prix fixes. Aucun frais caché. Modèles français d’abord.'
   },
-  miniCourse: {
-    heading: 'NOUVEAU\u00a0: Comprenez les lois 25 et 96 en moins d\u2019une heure.',
-    subheading: 'Vous craignez les amendes? Ce mini-cours autonome vous simplifie la conformit\u00e9.',
-    list: [
-      'Mod\u00e8les de messages bilingues (courriels, SMS, demandes d\u2019avis)',
-      'Listes de v\u00e9rification avec liens vers les sources officielles',
-      'Exemples r\u00e9els pour PME qu\u00e9b\u00e9coises',
-      'Moins d\u2019une heure pour tout comprendre'
-    ],
-    cta: 'D\u00e9couvrir le mini-cours'
-  },
-  fullCourse: {
-    heading: 'Bient\u00f4t\u00a0: Ma\u00eetrise compl\u00e8te des automatisations',
-    subheading: 'Apprenez \u00e0 automatiser la capture de prospects, les rappels, les paiements et les avis clients.',
-    list: [
-      'Le\u00e7ons pas \u00e0 pas avec d\u00e9mos r\u00e9elles',
-      'Mod\u00e8les bilingues fournis',
-      'Con\u00e7u pour les cliniques, commerces et services du Qu\u00e9bec'
-    ],
-    cta: 'Rejoindre la liste d\u2019attente'
-  },
-  courses: {
-    title: "Apprenez à automatiser et rester conforme",
-    subheading: "Des formations conçues pour les entreprises québécoises qui veulent clarté, contrôle et croissance conforme."
+  roi: {
+    title: '149 $ vs 900 $+ perdus chaque mois',
+    without: '3 patients manqués/mois = 900 $+ perdus.',
+    with: 'Pack à 149 $ → réponses instantanées, moins d’absences.',
+    note: 'La plupart des cliniques rentabilisent le pack la première semaine.'
   },
   proof: {
-    heading: 'Pensé pour',
-    highlight: ' les PME du Québec',
-    subheading: 'Chaque automatisation est testée en direct avant d\u2019\u00eatre mise en place. Mon contenu, mes messages et mes rappels respectent la Loi 96, sont offerts en français d\u2019abord, et adapt\u00e9s \u00e0 votre r\u00e9alit\u00e9 d\u2019affaires locale.',
-    calloutHeading: '',
-    calloutText: '',
-    items: [],
-    button: ''
+    title: 'Les cliniques qui automatisent voient des résultats rapides.',
+    bullets: [
+      '25–50 % d’absences en moins',
+      '5× plus de rendez-vous réservés grâce aux SMS instantanés',
+      '3× plus d’avis Google en 30–60 jours'
+    ]
   },
   faq: {
-    heading: 'Foire aux',
-    highlight: ' questions',
-    subheading: 'Tout ce qu’il faut savoir pour démarrer',
+    title: 'FAQ',
     list: [
-      { question: 'En combien de temps mon automatisation sera prête ?', answer: 'La plupart des installations sont complétées en 1 à 2 semaines après la démo. Je m’occupe de tout le côté technique pendant que vous gérez votre entreprise.' },
-      { question: 'Est-ce vraiment conforme à la Loi 96 ?', answer: 'Absolument. Chaque message et workflow est vérifié pour conformité Loi 96. Je fournis la documentation requise pour preuve d’audit.' },
-      { question: 'Et si je ne suis pas techno ?', answer: 'C’est parfait—c’est conçu pour ça ! Vous n’avez pas à comprendre la technique : voyez les résultats, je m’occupe de toute la configuration.' },
-      { question: 'Combien ça coûte ?', answer: "Les tarifs dépendent de vos besoins et de la taille de votre entreprise. Prix fixe, sans surprise. On discute du tarif exact lors de votre démo gratuite." },
-      { question: 'Pouvez-vous nous aider avec l’adoption de l’IA ?', answer: "Avec plaisir ! Je reste à l’affût des dernières tendances IA pour PME. Si vous voulez en discuter, mentionnez-le lors de votre démo." }
+      { question: 'En combien de temps pouvons-nous lancer?', answer: 'La plupart sont en ligne 1–2 semaines après votre démo.' },
+      { question: 'Est-ce vraiment conforme à la Loi 96/Loi 25?', answer: 'Oui. Messages en français d’abord, anglais sur demande, modèles vérifiés. Documentation fournie.' },
+      { question: 'Dois-je être technique?', answer: 'Non. Vous le voyez fonctionner d’abord; je m’occupe de l’installation et du transfert.' },
+      { question: 'Combien ça coûte?', answer: 'Packs DIY 149 $ chacun • Audit 249 $ • Système complet 1 499 $.' }
     ]
   },
   finalCTA: {
-    tagline: '',
-    heading: 'Vous avez des suivis \u00e0 automatiser?',
-    highlight: ' On commence avec une vraie d\u00e9mo.',
-    subheading: '',
-    nameLabel: 'Nom *',
-    namePlaceholder: 'Votre nom complet',
-    emailLabel: 'Courriel *',
-    emailPlaceholder: 'votre@courriel.com',
-    businessLabel: 'Type d’entreprise *',
-    businessPlaceholder: 'Sélectionnez votre secteur',
-    businessOptions: ['Sélectionnez votre secteur', 'Clinique médicale/dentaire', 'Entreprise de bien-être/spa', 'Commerçant/entrepreneur', 'Autre service'],
-    painLabel: 'Votre principal enjeu',
-    painPlaceholder: 'Quel est votre plus grand défi : suivis, absences, avis ?',
-    submit: 'R\u00e9server une d\u00e9monstration gratuite',
-    or: 'Ou, posez-moi votre question ici :',
-    sticky: 'Réserver une démo'
+    title: 'Commencez gratuitement. Restez conforme. Croissez plus vite.',
+    sub: 'Téléchargez la checklist maintenant — passez aux packs quand vous serez prêt.',
+    primary: 'Télécharger la checklist',
+    primaryHref: '/checklist',
+    secondary: 'Voir les packs',
+    secondaryHref: '/packs'
   },
   trustBadge: 'Conçu pour le Québec • Démo en direct • Bilingue et conforme à la Loi 96',
   partners: {
     title: 'Partenaires de confiance'
   },
   footer: {
-    blurb: "Automatisation bilingue pour PME québécoises. Conçu pour aujourd’hui, prêt pour demain.",
+    blurb: 'Automatisation bilingue pour les PME du Québec. Conçu pour aujourd’hui, prêt pour l’IA de demain.',
     language: 'Pour tout le Québec • FR/EN',
     services: 'Services',
     servicesList: ['Suivi des clients potentiels', 'Rappels de rendez-vous', 'Gestion des avis', 'Conformité Loi 96'],
@@ -136,8 +107,9 @@ const fr: TranslationKeys = {
     location: 'Québec, Canada',
     privacy: 'Politique de confidentialité',
     copyright: '© 2024 Simon Paris Consulting. Tous droits réservés.',
-    curiosity: "Curieux des prochaines avancées IA pour PME ? Écrivez à Simon."
+    curiosity: 'Curieux des prochaines avancées IA pour PME ? Écrivez à Simon.'
   }
 };
 
 export default fr;
+


### PR DESCRIPTION
## Summary
- tighten problem section highlighting ghosted leads, missed appointments, late invoices and compliance uncertainty
- introduce growth engine, productized offer cards, ROI math and simplified final CTA banner
- refresh FAQ and social proof content with clear bilingual messaging

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4af7326fc832381842c29bff972ce