### PR TITLE
Refresh post-hero sections with checklist lead magnet

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -176,7 +176,7 @@ const Hero = () => {
 
         <h1 className="text-hero text-white mb-6 leading-tight tracking-tight">
           <span>{t.hero.h1_part1} </span>
-          <span className="text-[#139E9B]">{t.hero.h1_accent}</span>
+          <span className="accent">{t.hero.h1_accent}</span>
         </h1>
 
         <p className="text-subhead !text-white/90 max-w-3xl mx-auto mb-4">{t.hero.subhead}</p>
@@ -375,26 +375,29 @@ const GrowthEngine = () => {
           />
         </div>
 
-        <div className="grid lg:grid-cols-3 gap-8">
+        <div className="grid lg:grid-cols-3 gap-8 items-stretch">
           {gears.map((gear, index) => (
             <div
               key={index}
-              className={`card-light p-6 md:p-8 text-center group transition-all duration-700 ${
+              className={`card-light p-6 md:p-8 flex flex-col items-center text-center group transition-all duration-700 ${
                 isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'
-              }`}
+              } h-full`}
               style={{ transitionDelay: `${index * 200}ms` }}
             >
-              <div className="w-16 h-16 rounded-2xl bg-[#2280FF] flex items-center justify-center mx-auto mb-6 group-hover:scale-110 transition-transform duration-300">
+              <div className="w-16 h-16 rounded-2xl bg-[#2280FF] flex items-center justify-center mb-6 group-hover:scale-110 transition-transform duration-300">
                 <gear.icon className="w-8 h-8 text-white" />
               </div>
 
               <h3
-                className="text-xl font-semibold text-gray-900 mb-4"
+                className="text-xl font-semibold text-gray-900 mb-4 text-center"
                 dangerouslySetInnerHTML={{ __html: gear.title }}
               />
-              <ul className="text-gray-700 space-y-1">
+              <ul className="text-gray-700 space-y-2 text-left w-full">
                 {gear.bullets.map((b: string, i: number) => (
-                  <li key={i}>{b}</li>
+                  <li key={i} className="flex items-start">
+                    <CheckCircle className="w-4 h-4 text-[#139E9B] mr-2 mt-1 flex-shrink-0" />
+                    <span>{b}</span>
+                  </li>
                 ))}
               </ul>
             </div>
@@ -523,7 +526,7 @@ const Checklist = () => {
       <div className="relative z-10 max-w-5xl mx-auto px-6 lg:px-8">
         <div className="card-light p-6 md:p-8 text-center">
           <div className="inline-flex items-center mb-4 text-sm font-medium text-gray-700">
-            <Shield className="w-5 h-5 text-teal-500 mr-2" />
+            <Shield className="w-5 h-5 text-[#139E9B] mr-2" />
             <span>{t.checklist.eyebrow}</span>
           </div>
           <h3
@@ -531,11 +534,11 @@ const Checklist = () => {
             dangerouslySetInnerHTML={{ __html: t.checklist.title }}
           />
           <p className="text-gray-700 mb-6">{t.checklist.sub}</p>
-          <ul className="grid grid-cols-1 md:grid-cols-2 gap-2 text-left text-gray-700 mb-6">
+          <ul className="space-y-2 text-left text-gray-700 mb-6">
             {t.checklist.points.map((p: string, i: number) => (
               <li key={i} className="flex items-start">
-                <CheckCircle className="w-4 h-4 text-teal-500 mr-2 mt-1" />
-                <span>{p}</span>
+                <CheckCircle className="w-4 h-4 text-[#139E9B] mr-2 mt-1 flex-shrink-0" />
+                <span dangerouslySetInnerHTML={{ __html: p }} />
               </li>
             ))}
           </ul>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useLanguage } from './LanguageProvider';
 import {
   Globe, Menu, X,
-  MessageSquare, CalendarX, Receipt, Shield,
+  MessageSquare, CalendarX, Receipt, Shield, CheckCircle,
   Zap, CalendarCheck, Star,
   Mail, MapPin, ChevronDown, ChevronUp
 } from 'lucide-react';
@@ -297,14 +297,17 @@ const ProblemSection = () => {
     <section id="automations" ref={sectionRef} className="relative py-16 lg:py-20 overflow-hidden" style={{ background: '#FFFFFF' }}>
       <div className="relative z-10 max-w-7xl mx-auto px-6 lg:px-8">
         <div className={`text-center mb-16 transition-all duration-1000 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}>
-          <h2 className="text-display text-gray-900 mb-6">{t.problems.title}</h2>
+          <h2
+            className="text-display text-gray-900 mb-6"
+            dangerouslySetInnerHTML={{ __html: t.problems.title }}
+          />
         </div>
 
         <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6 lg:gap-8">
           {problems.map((problem, index) => (
             <div
               key={index}
-              className={`card-light p-6 text-center group transition-all duration-700 ${
+              className={`card-light p-6 md:p-8 text-center group transition-all duration-700 ${
                 isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'
               }`}
               style={{ transitionDelay: `${index * 150}ms` }}
@@ -313,9 +316,10 @@ const ProblemSection = () => {
                 <problem.icon className="w-8 h-8 text-[#2280FF]" />
               </div>
 
-              <h3 className="text-lg lg:text-xl font-semibold text-gray-900 mb-3">
-                {problem.title}
-              </h3>
+              <h3
+                className="text-lg lg:text-xl font-semibold text-gray-900 mb-3"
+                dangerouslySetInnerHTML={{ __html: problem.title }}
+              />
 
               <p className="text-gray-700 leading-relaxed text-sm lg:text-base">
                 {problem.body}
@@ -324,7 +328,10 @@ const ProblemSection = () => {
           ))}
         </div>
 
-        <p className="text-center text-gray-700 mt-8">{t.problems.note}</p>
+        <p
+          className="text-center text-gray-700 mt-8"
+          dangerouslySetInnerHTML={{ __html: t.problems.note }}
+        />
       </div>
     </section>
   );
@@ -362,14 +369,17 @@ const GrowthEngine = () => {
     <section ref={sectionRef} className="relative py-16 lg:py-20 overflow-hidden" style={{ background: '#F9FAFB' }}>
       <div className="relative z-10 max-w-7xl mx-auto px-6 lg:px-8">
         <div className={`text-center mb-16 transition-all duration-1000 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}>
-          <h2 className="text-display text-gray-900 mb-6">{t.growth.title}</h2>
+          <h2
+            className="text-display text-gray-900 mb-6"
+            dangerouslySetInnerHTML={{ __html: t.growth.title }}
+          />
         </div>
 
         <div className="grid lg:grid-cols-3 gap-8">
           {gears.map((gear, index) => (
             <div
               key={index}
-              className={`card-light p-8 text-center group transition-all duration-700 ${
+              className={`card-light p-6 md:p-8 text-center group transition-all duration-700 ${
                 isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'
               }`}
               style={{ transitionDelay: `${index * 200}ms` }}
@@ -378,8 +388,15 @@ const GrowthEngine = () => {
                 <gear.icon className="w-8 h-8 text-white" />
               </div>
 
-              <h3 className="text-xl font-semibold text-gray-900 mb-4">{gear.title}</h3>
-              <p className="text-gray-700 leading-relaxed">{gear.desc}</p>
+              <h3
+                className="text-xl font-semibold text-gray-900 mb-4"
+                dangerouslySetInnerHTML={{ __html: gear.title }}
+              />
+              <ul className="text-gray-700 space-y-1">
+                {gear.bullets.map((b: string, i: number) => (
+                  <li key={i}>{b}</li>
+                ))}
+              </ul>
             </div>
           ))}
         </div>
@@ -420,17 +437,23 @@ const OfferCards = () => {
   return (
     <section ref={sectionRef} className="relative py-16 lg:py-20 overflow-hidden" style={{ background: '#FFFFFF' }}>
       <div className="relative z-10 max-w-7xl mx-auto px-6 lg:px-8 text-center">
-        <h2 className={`text-display text-gray-900 mb-12 transition-all duration-1000 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}>{t.offers.heading}</h2>
+        <h2
+          className={`text-display text-gray-900 mb-12 transition-all duration-1000 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}
+          dangerouslySetInnerHTML={{ __html: t.offers.heading }}
+        />
 
         <div className={`grid md:grid-cols-3 gap-8 transition-all duration-1000 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}>
           {offers.map((offer, index) => (
-            <div key={index} className="card-light p-8 flex flex-col relative">
+            <div key={index} className="card-light p-6 md:p-8 flex flex-col relative">
               {offer.badge && (
                 <span className="absolute top-4 right-4 text-xs font-semibold bg-[#2280FF] text-white px-2 py-1 rounded-full">
                   {offer.badge}
                 </span>
               )}
-              <h3 className="text-xl font-semibold text-gray-900 mb-2">{offer.title}</h3>
+              <h3
+                className="text-xl font-semibold text-gray-900 mb-2"
+                dangerouslySetInnerHTML={{ __html: offer.title }}
+              />
               <p className="text-2xl font-bold text-gray-900 mb-4">{offer.price}</p>
               <p className="text-gray-700 mb-6 flex-1">{offer.desc}</p>
               <a href={offer.href} className="btn-primary mt-auto">{offer.cta}</a>
@@ -468,15 +491,18 @@ const ROIMath = () => {
     <section ref={sectionRef} className="relative py-16 lg:py-20 overflow-hidden" style={{ background: '#F9FAFB' }}>
       <div className="relative z-10 max-w-5xl mx-auto px-6 lg:px-8 text-center">
         <div className={`mb-12 transition-all duration-1000 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}>
-          <h2 className="text-display text-gray-900 mb-6">{t.roi.title}</h2>
+          <h2
+            className="text-display text-gray-900 mb-6"
+            dangerouslySetInnerHTML={{ __html: t.roi.title }}
+          />
         </div>
 
         <div className={`grid md:grid-cols-2 gap-8 transition-all duration-1000 delay-200 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}>
-          <div className="card-light p-8">
+          <div className="card-light p-6 md:p-8">
             <h3 className="text-xl font-semibold text-gray-900 mb-2">{lang === 'fr' ? 'Sans automatisation' : 'Without automation'}</h3>
             <p className="text-gray-700">{t.roi.without}</p>
           </div>
-          <div className="card-light p-8">
+          <div className="card-light p-6 md:p-8">
             <h3 className="text-xl font-semibold text-gray-900 mb-2">{lang === 'fr' ? 'Avec automatisation' : 'With automation'}</h3>
             <p className="text-gray-700">{t.roi.with}</p>
           </div>
@@ -484,6 +510,40 @@ const ROIMath = () => {
 
         <p className="text-gray-700 mt-8">{t.roi.note}</p>
         <p className="text-gray-700 text-xs mt-2">{t.roi.disclaimer}</p>
+      </div>
+    </section>
+  );
+};
+
+// Checklist Component
+const Checklist = () => {
+  const { t } = useLanguage();
+  return (
+    <section className="relative py-16 lg:py-20 overflow-hidden" style={{ background: '#FFFFFF' }}>
+      <div className="relative z-10 max-w-5xl mx-auto px-6 lg:px-8">
+        <div className="card-light p-6 md:p-8 text-center">
+          <div className="inline-flex items-center mb-4 text-sm font-medium text-gray-700">
+            <Shield className="w-5 h-5 text-teal-500 mr-2" />
+            <span>{t.checklist.eyebrow}</span>
+          </div>
+          <h3
+            className="text-headline text-gray-900 mb-4"
+            dangerouslySetInnerHTML={{ __html: t.checklist.title }}
+          />
+          <p className="text-gray-700 mb-6">{t.checklist.sub}</p>
+          <ul className="grid grid-cols-1 md:grid-cols-2 gap-2 text-left text-gray-700 mb-6">
+            {t.checklist.points.map((p: string, i: number) => (
+              <li key={i} className="flex items-start">
+                <CheckCircle className="w-4 h-4 text-teal-500 mr-2 mt-1" />
+                <span>{p}</span>
+              </li>
+            ))}
+          </ul>
+          <a href={t.checklist.href} className="btn-primary px-8 py-4">
+            {t.checklist.cta}
+          </a>
+          <p className="text-xs text-gray-500 mt-4">{t.checklist.disclaimer}</p>
+        </div>
       </div>
     </section>
   );
@@ -558,33 +618,42 @@ const FAQ = () => {
     <section ref={sectionRef} className="relative py-12 lg:py-20 overflow-hidden" style={{ background: '#FFFFFF' }}>
       <div className="relative z-10 max-w-4xl mx-auto px-6 lg:px-8">
         <div className={`text-center mb-16 transition-all duration-1000 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}>
-          <h2 className="text-display text-gray-900 mb-6">{t.faq.title}</h2>
+          <h2
+            className="text-display text-gray-900 mb-6"
+            dangerouslySetInnerHTML={{ __html: t.faq.title }}
+          />
         </div>
         
         <div className={`space-y-4 transition-all duration-1000 delay-300 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}>
           {faqs.map((faq, index) => (
             <div key={index} className="card-light overflow-hidden">
               <button
-                className="w-full px-8 py-6 text-left flex justify-between items-center hover:bg-white/5 transition-colors"
+                className="w-full px-6 md:px-8 py-6 text-left flex justify-between items-center hover:bg-white/5 transition-colors"
                 onClick={() => setOpenFAQ(openFAQ === index ? null : index)}
               >
-                <span className="text-lg font-semibold text-gray-900 pr-8">
-                  {faq.question}
-                </span>
+                <span
+                  className="text-lg font-semibold text-gray-900 pr-8"
+                  dangerouslySetInnerHTML={{ __html: faq.question }}
+                />
                 {openFAQ === index ? (
                   <ChevronUp className="w-6 h-6 text-[#2280FF] flex-shrink-0" />
                 ) : (
                   <ChevronDown className="w-6 h-6 text-[#2280FF] flex-shrink-0" />
                 )}
               </button>
-              
-              <div className={`transition-all duration-300 overflow-hidden ${
-                openFAQ === index ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'
-              }`}>
-                <div className="px-8 pb-6">
-                  <p className="text-gray-700 leading-relaxed">
-                    {faq.answer}
-                  </p>
+
+              <div
+                className={`transition-all duration-300 overflow-hidden ${
+                  openFAQ === index ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'
+                }`}
+              >
+                <div className="px-6 md:px-8 pb-6">
+                  <p className="text-gray-700 mb-2">{faq.answer.intro}</p>
+                  <ul className="list-disc list-inside text-gray-700 space-y-1">
+                    {faq.answer.bullets.map((b: string, i: number) => (
+                      <li key={i}>{b}</li>
+                    ))}
+                  </ul>
                 </div>
               </div>
             </div>
@@ -717,6 +786,7 @@ function App() {
         <GrowthEngine />
         <OfferCards />
       <ROIMath />
+      <Checklist />
       <ProofSection />
       <FAQ />
       <FinalCTA />

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,1 +1,1 @@
-export const PACK_PRICE = 199;
+export const PACK_PRICE = 149;

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -19,28 +19,28 @@ export const en = {
       secondaryCta: `See Automation Packs ($${PACK_PRICE})`
     },
   problems: {
-    title: 'Why clinics <span class="text-teal-500 font-semibold">lose money</span> every week…',
+    title: 'Why clinics <span class="accent">lose money</span> every week…',
     list: [
-      { title: 'Ignored <span class="text-teal-500 font-semibold">leads</span>', body: 'Patients book elsewhere.' },
-      { title: 'Missed <span class="text-teal-500 font-semibold">appointments</span>', body: 'Empty chairs at peak hours.' },
-      { title: 'Late <span class="text-teal-500 font-semibold">invoices</span>', body: 'Cash flow gets squeezed.' },
-      { title: 'Legal <span class="text-teal-500 font-semibold">uncertainty</span>', body: 'Messages may breach Law 25/Bill 96.' }
+      { title: 'Ignored <span class="accent">leads</span>', body: 'Patients book elsewhere.' },
+      { title: 'Missed <span class="accent">appointments</span>', body: 'Empty chairs at peak hours.' },
+      { title: 'Late <span class="accent">invoices</span>', body: 'Cash flow gets squeezed.' },
+      { title: 'Legal <span class="accent">uncertainty</span>', body: 'Messages may breach Law 25/Bill 96.' }
     ],
     note: 'You can fix all of this with simple <span class="font-semibold">bilingual automation</span>.'
   },
   growth: {
-    title: 'The <span class="text-teal-500 font-semibold">growth engine</span> for your clinic: simple, bilingual, compliant.',
+    title: 'The <span class="accent">growth engine</span> for your clinic: simple, bilingual, compliant.',
     gears: [
       {
-        title: 'Speed‑to‑Lead <span class="text-teal-500 font-semibold">SMS</span>',
+        title: 'Speed‑to‑Lead <span class="accent">SMS</span>',
         bullets: ['Replies in under 5 min', 'FR-first, then EN', 'Integrates web, calls, social']
       },
       {
-        title: 'No‑Show <span class="text-teal-500 font-semibold">Chaser</span> + <span class="text-teal-500 font-semibold">Reminders</span>',
+        title: 'No‑Show <span class="accent">Chaser</span> + <span class="accent">Reminders</span>',
         bullets: ['24h & 2h reminders', 'Easy reschedule link', '25–50% fewer no-shows']
       },
       {
-        title: 'Review <span class="text-teal-500 font-semibold">Engine</span> + <span class="text-teal-500 font-semibold">Compliance</span>',
+        title: 'Review <span class="accent">Engine</span> + <span class="accent">Compliance</span>',
         bullets: ['Polite FR/EN review asks', '3× more reviews in 30–60 days', 'Audit-ready docs (Law 25/96)']
       }
     ],
@@ -75,7 +75,7 @@ export const en = {
     note: 'Flat pricing. No hidden fees. French-first templates.'
   },
   roi: {
-    title: 'Why <span class="text-teal-500 font-semibold">$149</span> beats <span class="text-teal-500 font-semibold">~$600–900</span> lost every month',
+    title: 'Why <span class="accent">$149</span> beats <span class="accent">~$600–900</span> lost every month',
     without: 'Lost leads, 3–4 no-shows, late invoices ≈ $600–900/mo',
     with: 'Pack from $149 → faster replies, fewer no‑shows, invoices on time',
     note: 'Many clinics recoup the pack in the first week.',
@@ -83,19 +83,17 @@ export const en = {
   },
   checklist: {
     eyebrow: 'Free',
-    title: 'Law 25 + Bill 96 <span class="text-teal-500 font-semibold">Compliance Checklist</span>',
-    sub: 'Spot common risks in 3 minutes across reminders and messages.',
+    title: 'Are you really <span class="accent">Law 25</span> ready?',
+    sub: 'Most clinics think they’re fine… until a no-show patient or audit proves otherwise. Download the free checklist to spot the hidden risks in your communication workflows.',
     points: [
-      'FR-first templates ready',
-      'Clear consent & opt-out',
-      'Timestamp every send',
-      'Plain, non-ambiguous language',
-      'Proof archive for audits',
-      'Bilingual message review'
+      'Is your SMS & email <span class="accent">consent wording</span> valid under Québec law?',
+      'Do you have <span class="accent">timestamped proof</span> for every message you send?',
+      'Are your reminders and follow-ups fully <span class="accent">FR-first</span>?',
+      'Can patients <span class="accent">opt-out</span> instantly, without risk of complaint?'
     ],
-    cta: 'Get the checklist',
+    cta: 'Download the Checklist',
     href: '/checklist',
-    disclaimer: 'No spam. Includes FR/EN templates.'
+    disclaimer: 'Free download. Instant access after signup. We’ll also send you practical updates on compliance & automation (unsubscribe anytime).'
   },
   proof: {
     title: 'Clinics that automate see results fast.',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -19,21 +19,30 @@ export const en = {
       secondaryCta: `See Automation Packs ($${PACK_PRICE})`
     },
   problems: {
-    title: 'Why clinics lose money every week…',
+    title: 'Why clinics <span class="text-teal-500 font-semibold">lose money</span> every week…',
     list: [
-      { title: 'Ignored leads', body: 'Patients wait and book elsewhere.' },
-      { title: 'Missed appointments', body: 'Empty chairs at peak hours.' },
-      { title: 'Late invoices', body: 'Cash flow gets squeezed.' },
-      { title: 'Legal uncertainty', body: 'Messages may breach Law 25/Bill 96.' }
+      { title: 'Ignored <span class="text-teal-500 font-semibold">leads</span>', body: 'Patients book elsewhere.' },
+      { title: 'Missed <span class="text-teal-500 font-semibold">appointments</span>', body: 'Empty chairs at peak hours.' },
+      { title: 'Late <span class="text-teal-500 font-semibold">invoices</span>', body: 'Cash flow gets squeezed.' },
+      { title: 'Legal <span class="text-teal-500 font-semibold">uncertainty</span>', body: 'Messages may breach Law 25/Bill 96.' }
     ],
-    note: 'You can fix all of this with simple bilingual automation.'
+    note: 'You can fix all of this with simple <span class="font-semibold">bilingual automation</span>.'
   },
   growth: {
-    title: 'Your clinic\u2019s growth engine: simple, bilingual, compliant.',
+    title: 'The <span class="text-teal-500 font-semibold">growth engine</span> for your clinic: simple, bilingual, compliant.',
     gears: [
-      { title: 'Speed\u2011to\u2011Lead SMS', desc: 'Reply before competitors.' },
-      { title: 'No\u2011Show Chaser + Reminders', desc: 'Fewer empty chairs every week.' },
-      { title: 'Review Engine + Compliance', desc: 'More 5\u2605 reviews, audit-ready docs.' }
+      {
+        title: 'Speed‑to‑Lead <span class="text-teal-500 font-semibold">SMS</span>',
+        bullets: ['Replies in under 5 min', 'FR-first, then EN', 'Integrates web, calls, social']
+      },
+      {
+        title: 'No‑Show <span class="text-teal-500 font-semibold">Chaser</span> + <span class="text-teal-500 font-semibold">Reminders</span>',
+        bullets: ['24h & 2h reminders', 'Easy reschedule link', '25–50% fewer no-shows']
+      },
+      {
+        title: 'Review <span class="text-teal-500 font-semibold">Engine</span> + <span class="text-teal-500 font-semibold">Compliance</span>',
+        bullets: ['Polite FR/EN review asks', '3× more reviews in 30–60 days', 'Audit-ready docs (Law 25/96)']
+      }
     ],
     cta: 'See the packs in action'
   },
@@ -66,12 +75,27 @@ export const en = {
     note: 'Flat pricing. No hidden fees. French-first templates.'
   },
   roi: {
-    title: `$${PACK_PRICE} vs ~$400 in lost appointments each month`,
-    without: '3 missed appointments/month \u2248 $300\u2013$400 lost in revenue',
-    with: `$${PACK_PRICE} pack \u2192 faster responses, fewer no-shows`,
-    note: 'Many clinics recoup the pack cost within the first week.',
-    disclaimer:
-      'Estimates assume a typical appointment value of ~$100\u2013150. Results will vary by clinic.'
+    title: 'Why <span class="text-teal-500 font-semibold">$149</span> beats <span class="text-teal-500 font-semibold">~$600–900</span> lost every month',
+    without: 'Lost leads, 3–4 no-shows, late invoices ≈ $600–900/mo',
+    with: 'Pack from $149 → faster replies, fewer no‑shows, invoices on time',
+    note: 'Many clinics recoup the pack in the first week.',
+    disclaimer: 'Estimates based on ~$120–150 per appointment and typical lead leakage in Québec. Results vary.'
+  },
+  checklist: {
+    eyebrow: 'Free',
+    title: 'Law 25 + Bill 96 <span class="text-teal-500 font-semibold">Compliance Checklist</span>',
+    sub: 'Spot common risks in 3 minutes across reminders and messages.',
+    points: [
+      'FR-first templates ready',
+      'Clear consent & opt-out',
+      'Timestamp every send',
+      'Plain, non-ambiguous language',
+      'Proof archive for audits',
+      'Bilingual message review'
+    ],
+    cta: 'Get the checklist',
+    href: '/checklist',
+    disclaimer: 'No spam. Includes FR/EN templates.'
   },
   proof: {
     title: 'Clinics that automate see results fast.',
@@ -86,27 +110,38 @@ export const en = {
     list: [
       {
         question: 'How quickly can you set up my automation?',
-        answer:
-          'Most setups are completed within 1\u20132 weeks after our demo call. I handle all the technical work while you focus on running your business.'
+        answer: {
+          intro: 'Faster than you think.',
+          bullets: ['Live within 1–2 weeks', 'Hands-on support included']
+        }
       },
       {
         question: 'Is this really compliant?',
-        answer:
-          'Absolutely. Every message template and automation workflow is reviewed for Bill 96 compliance. I provide documentation showing compliance for audit purposes.'
+        answer: {
+          intro: 'Yes, and documented.',
+          bullets: ['Bill 25/96-checked templates', 'Audit-ready proof provided']
+        }
       },
       {
         question: "What if I'm not tech-savvy?",
-        answer:
-          "Perfect! That's exactly who this is built for. You don't need to understand the technology—just see the results. I handle all the technical setup and maintenance."
+        answer: {
+          intro: 'Built for non-tech folks.',
+          bullets: ['We set everything up', 'Human support in English & French']
+        }
       },
       {
         question: 'How much does it cost?',
-        answer: `From $${PACK_PRICE}. Flat pricing. No long-term contract.`
+        answer: {
+          intro: `From $${PACK_PRICE}.`,
+          bullets: ['Flat pricing, no contract', 'ROI within days for many']
+        }
       },
       {
         question: 'Can you help us with AI adoption or strategy?',
-        answer:
-          "Absolutely. I'm always researching the latest AI tools and trends for SMBs. If you want to talk about how AI could help your business, just mention it when you book a demo."
+        answer: {
+          intro: 'Absolutely.',
+          bullets: ['Always testing new AI tools', 'Ask during the demo']
+        }
       }
     ]
   },

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -19,28 +19,28 @@ const fr: TranslationKeys = {
     secondaryCta: `Voir les packs (${PACK_PRICE} $)`
   },
   problems: {
-    title: 'Pourquoi les cliniques <span class="text-teal-500 font-semibold">perdent de l’argent</span> chaque semaine…',
+    title: 'Pourquoi les cliniques <span class="accent">perdent de l’argent</span> chaque semaine…',
     list: [
-      { title: 'Leads <span class="text-teal-500 font-semibold">ignorés</span>', body: 'Les patients réservent ailleurs.' },
-      { title: 'Rendez‑vous <span class="text-teal-500 font-semibold">manqués</span>', body: 'Des chaises vides aux heures de pointe.' },
-      { title: 'Factures <span class="text-teal-500 font-semibold">en retard</span>', body: 'Moins de liquidités chaque mois.' },
-      { title: 'Incertitude <span class="text-teal-500 font-semibold">légale</span>', body: 'Risque de non‑conformité (Loi 25/Loi 96).' }
+      { title: 'Leads <span class="accent">ignorés</span>', body: 'Les patients réservent ailleurs.' },
+      { title: 'Rendez‑vous <span class="accent">manqués</span>', body: 'Des chaises vides aux heures de pointe.' },
+      { title: 'Factures <span class="accent">en retard</span>', body: 'Moins de liquidités chaque mois.' },
+      { title: 'Incertitude <span class="accent">légale</span>', body: 'Risque de non‑conformité (Loi 25/Loi 96).' }
     ],
     note: 'Tout se corrige avec une <span class="font-semibold">automatisation bilingue</span> simple.'
   },
   growth: {
-    title: 'Le <span class="text-teal-500 font-semibold">moteur de croissance</span> de votre clinique : simple, bilingue, conforme.',
+    title: 'Le <span class="accent">moteur de croissance</span> de votre clinique : simple, bilingue, conforme.',
     gears: [
       {
-        title: 'SMS <span class="text-teal-500 font-semibold">vitesse‑à‑lead</span>',
+        title: 'SMS <span class="accent">vitesse‑à‑lead</span>',
         bullets: ['Réponse en moins de 5 min', 'Priorité FR → EN', 'Intégration web, appels, réseaux sociaux']
       },
       {
-        title: 'Relance d’<span class="text-teal-500 font-semibold">absences</span> + <span class="text-teal-500 font-semibold">rappels</span>',
+        title: 'Relance d’<span class="accent">absences</span> + <span class="accent">rappels</span>',
         bullets: ['Rappels 24 h & 2 h', 'Lien simple pour replanifier', '25–50 % d’absences en moins']
       },
       {
-        title: 'Moteur d’<span class="text-teal-500 font-semibold">avis</span> + <span class="text-teal-500 font-semibold">conformité</span>',
+        title: 'Moteur d’<span class="accent">avis</span> + <span class="accent">conformité</span>',
         bullets: ['Demandes d’avis polies FR/EN', '3× plus d’avis en 30–60 jours', 'Docs prêts pour audit (Loi 25/96)']
       }
     ],
@@ -75,7 +75,7 @@ const fr: TranslationKeys = {
     note: 'Prix fixes. Aucun frais caché. Modèles français d’abord.'
   },
   roi: {
-    title: 'Pourquoi <span class="text-teal-500 font-semibold">149 $</span> bat <span class="text-teal-500 font-semibold">~600–900 $</span> perdus chaque mois',
+    title: 'Pourquoi <span class="accent">149 $</span> bat <span class="accent">~600–900 $</span> perdus chaque mois',
     without: 'Leads perdus, 3–4 no‑shows, factures en retard ≈ 600–900 $ / mois',
     with: 'Pack dès 149 $ → réponses plus rapides, moins d’absences, factures à temps',
     note: 'Beaucoup de cliniques rentabilisent le pack dès la première semaine.',
@@ -83,19 +83,17 @@ const fr: TranslationKeys = {
   },
   checklist: {
     eyebrow: 'Gratuit',
-    title: 'Checklist de <span class="text-teal-500 font-semibold">conformité</span> (Loi 25 + Loi 96)',
-    sub: 'Repérez en 3 minutes les risques courants dans vos messages et rappels.',
+    title: 'Êtes-vous vraiment prêt pour la <span class="accent">Loi 25</span>?',
+    sub: 'La plupart des cliniques croient que oui… jusqu’à ce qu’un patient manqué ou un audit révèle le contraire. Téléchargez la liste gratuite pour découvrir les zones à risque dans vos communications.',
     points: [
-      'FR d’abord : gabarits prêts',
-      'Consentement + retrait clairs',
-      'Horodatage des envois',
-      'Langage simple, non ambigu',
-      'Archivage des preuves (audit)',
-      'Révision bilingue des messages'
+      'Vos <span class="accent">formulaires de consentement</span> pour SMS et courriels sont-ils vraiment conformes?',
+      'Avez-vous une <span class="accent">preuve horodatée</span> de chaque message envoyé?',
+      'Vos rappels et suivis sont-ils 100 % <span class="accent">en français d’abord</span> (FR-first)?',
+      'Vos patients peuvent-ils se <span class="accent">désabonner</span> instantanément, sans plainte possible?'
     ],
-    cta: 'Télécharger la checklist',
+    cta: 'Télécharger la Liste',
     href: '/fr/checklist',
-    disclaimer: 'Aucun spam. Vous recevrez aussi des modèles FR/EN.'
+    disclaimer: 'Téléchargement gratuit. Accès immédiat après inscription. Nous vous enverrons aussi des conseils pratiques sur la conformité et l’automatisation (désabonnement en tout temps).'
   },
   proof: {
     title: 'Les cliniques qui automatisent voient des résultats rapides.',

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -19,21 +19,30 @@ const fr: TranslationKeys = {
     secondaryCta: `Voir les packs (${PACK_PRICE} $)`
   },
   problems: {
-    title: 'Pourquoi les cliniques perdent de l’argent chaque semaine…',
+    title: 'Pourquoi les cliniques <span class="text-teal-500 font-semibold">perdent de l’argent</span> chaque semaine…',
     list: [
-      { title: 'Leads ignorés', body: 'Les patients réservent ailleurs.' },
-      { title: 'Rendez-vous manqués', body: 'Des chaises vides aux heures de pointe.' },
-      { title: 'Factures en retard', body: 'Moins de liquidités chaque mois.' },
-      { title: 'Incertitude légale', body: 'Risque de non-conformité (Loi 25/Loi 96).' }
+      { title: 'Leads <span class="text-teal-500 font-semibold">ignorés</span>', body: 'Les patients réservent ailleurs.' },
+      { title: 'Rendez‑vous <span class="text-teal-500 font-semibold">manqués</span>', body: 'Des chaises vides aux heures de pointe.' },
+      { title: 'Factures <span class="text-teal-500 font-semibold">en retard</span>', body: 'Moins de liquidités chaque mois.' },
+      { title: 'Incertitude <span class="text-teal-500 font-semibold">légale</span>', body: 'Risque de non‑conformité (Loi 25/Loi 96).' }
     ],
-    note: 'Tout se corrige avec une automatisation bilingue simple.'
+    note: 'Tout se corrige avec une <span class="font-semibold">automatisation bilingue</span> simple.'
   },
   growth: {
-    title: 'Le moteur de croissance de votre clinique : simple, bilingue, conforme.',
+    title: 'Le <span class="text-teal-500 font-semibold">moteur de croissance</span> de votre clinique : simple, bilingue, conforme.',
     gears: [
-      { title: 'SMS vitesse-à-lead', desc: 'Répondez avant vos concurrents.' },
-      { title: 'Relance d’absences + rappels', desc: 'Moins de chaises vides chaque semaine.' },
-      { title: 'Moteur d’avis + conformité', desc: 'Plus d’avis 5★, docs prêts pour audit.' }
+      {
+        title: 'SMS <span class="text-teal-500 font-semibold">vitesse‑à‑lead</span>',
+        bullets: ['Réponse en moins de 5 min', 'Priorité FR → EN', 'Intégration web, appels, réseaux sociaux']
+      },
+      {
+        title: 'Relance d’<span class="text-teal-500 font-semibold">absences</span> + <span class="text-teal-500 font-semibold">rappels</span>',
+        bullets: ['Rappels 24 h & 2 h', 'Lien simple pour replanifier', '25–50 % d’absences en moins']
+      },
+      {
+        title: 'Moteur d’<span class="text-teal-500 font-semibold">avis</span> + <span class="text-teal-500 font-semibold">conformité</span>',
+        bullets: ['Demandes d’avis polies FR/EN', '3× plus d’avis en 30–60 jours', 'Docs prêts pour audit (Loi 25/96)']
+      }
     ],
     cta: 'Voir les packs en action'
   },
@@ -66,12 +75,27 @@ const fr: TranslationKeys = {
     note: 'Prix fixes. Aucun frais caché. Modèles français d’abord.'
   },
   roi: {
-    title: `${PACK_PRICE} $ vs \u2248 400 $ de revenus manqu\u00e9s par mois`,
-    without: '3 rendez-vous manqu\u00e9s/mois \u2248 300\u2013400 $ de revenus perdus',
-    with: `Pack \u00e0 ${PACK_PRICE} $ \u2192 r\u00e9ponses plus rapides, moins d\u2019absences`,
-    note: 'Plusieurs cliniques rentabilisent le pack d\u00e8s la premi\u00e8re semaine.',
-    disclaimer:
-      'Estimations bas\u00e9es sur une valeur de rendez-vous typique de 100\u2013150 $. R\u00E9sultats variables.'
+    title: 'Pourquoi <span class="text-teal-500 font-semibold">149 $</span> bat <span class="text-teal-500 font-semibold">~600–900 $</span> perdus chaque mois',
+    without: 'Leads perdus, 3–4 no‑shows, factures en retard ≈ 600–900 $ / mois',
+    with: 'Pack dès 149 $ → réponses plus rapides, moins d’absences, factures à temps',
+    note: 'Beaucoup de cliniques rentabilisent le pack dès la première semaine.',
+    disclaimer: 'Estimations basées sur ~120–150 $ par rendez‑vous et des pertes typiques de leads au Québec. Résultats variables.'
+  },
+  checklist: {
+    eyebrow: 'Gratuit',
+    title: 'Checklist de <span class="text-teal-500 font-semibold">conformité</span> (Loi 25 + Loi 96)',
+    sub: 'Repérez en 3 minutes les risques courants dans vos messages et rappels.',
+    points: [
+      'FR d’abord : gabarits prêts',
+      'Consentement + retrait clairs',
+      'Horodatage des envois',
+      'Langage simple, non ambigu',
+      'Archivage des preuves (audit)',
+      'Révision bilingue des messages'
+    ],
+    cta: 'Télécharger la checklist',
+    href: '/fr/checklist',
+    disclaimer: 'Aucun spam. Vous recevrez aussi des modèles FR/EN.'
   },
   proof: {
     title: 'Les cliniques qui automatisent voient des résultats rapides.',
@@ -86,27 +110,38 @@ const fr: TranslationKeys = {
     list: [
       {
         question: 'En combien de temps pouvez-vous configurer mon automatisation?',
-        answer:
-          'La plupart des configurations sont termin\u00e9es en 1\u20132 semaines apr\u00e8s notre appel d\u00e9mo. Je m’occupe de toute la partie technique pendant que vous g\u00e9rez votre entreprise.'
+        answer: {
+          intro: 'Rapide, sans tracas.',
+          bullets: ['Configuration en 1–2 semaines', 'Support complet pendant l’installation']
+        }
       },
       {
         question: 'C’est vraiment conforme?',
-        answer:
-          'Absolument. Chaque mod\u00e8le de message et flux d’automatisation est v\u00e9rifi\u00e9 pour la conformit\u00e9 \u00e0 la Loi 96. Je fournis une documentation montrant la conformit\u00e9 pour les audits.'
+        answer: {
+          intro: 'Oui, documenté.',
+          bullets: ['Modèles vérifiés Loi 25/96', 'Preuves prêtes pour audit']
+        }
       },
       {
-        question: 'Et si je ne suis pas \u00e0 l’aise avec la technologie?',
-        answer:
-          'Parfait! C’est justement pour vous que c’est con\u00e7u. Vous n’avez pas besoin de comprendre la technologie — voyez simplement les r\u00e9sultats. Je m’occupe de toute l’installation et de la maintenance.'
+        question: 'Et si je ne suis pas à l’aise avec la technologie?',
+        answer: {
+          intro: 'Pensé pour les non‑tech.',
+          bullets: ['Installation gérée pour vous', 'Accompagnement humain en français']
+        }
       },
       {
-        question: 'Combien \u00e7a co\u00fbte?',
-        answer: `\u00c0 partir de ${PACK_PRICE} $. Prix fixes. Sans contrat \u00e0 long terme.`
+        question: 'Combien ça coûte?',
+        answer: {
+          intro: `À partir de ${PACK_PRICE} $.`,
+          bullets: ['Prix fixes, aucun contrat', 'Retour rapide sur investissement']
+        }
       },
       {
-        question: 'Pouvez-vous nous aider avec l’adoption ou la strat\u00e9gie IA?',
-        answer:
-          'Absolument. Je suis toujours \u00e0 l’aff\u00fbt des derniers outils et tendances IA pour les PME. Si vous voulez discuter de la fa\u00e7on dont l’IA peut aider votre entreprise, mentionnez-le lors de la d\u00e9mo.'
+        question: 'Pouvez-vous nous aider avec l’adoption ou la stratégie IA?',
+        answer: {
+          intro: 'Bien sûr.',
+          bullets: ['Veille constante des outils IA', 'Conseils lors de la démo']
+        }
       }
     ]
   },

--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,12 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer utilities {
+  .accent {
+    @apply text-[#139E9B] font-semibold;
+  }
+}
+
 :root {
   --primary-blue: #2280FF;
   --accent-teal: theme('colors.teal.400');

--- a/src/index.css
+++ b/src/index.css
@@ -183,34 +183,22 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 /* Premium Cards */
+/* Dark themed card */
 .card-dark {
-  background: rgba(255, 255, 255, 0.05);
-  backdrop-filter: blur(20px);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 20px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
-  transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  @apply bg-white/5 backdrop-blur-xl rounded-2xl border border-white/10 shadow-md transition-shadow;
 }
 
 .card-dark:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 20px 64px rgba(0, 0, 0, 0.4);
-  border-color: rgba(34, 128, 255, 0.3);
+  @apply shadow-lg;
 }
 
 /* Light themed card for white sections */
 .card-light {
-  background: #ffffff;
-  border: 1px solid rgba(0, 0, 0, 0.1);
-  border-radius: 20px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.05);
-  transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  @apply bg-white rounded-2xl border border-gray-200/60 shadow-md transition-shadow;
 }
 
 .card-light:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 20px 64px rgba(0, 0, 0, 0.1);
-  border-color: rgba(34, 128, 255, 0.3);
+  @apply shadow-lg;
 }
 
 .card-glass {


### PR DESCRIPTION
## Summary
- thicken card styling and re-enable accent spans
- rewrite pain, solution, ROI, and FAQ copy in FR/EN
- add bilingual compliance checklist block

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4e9beeed08323ae12a9dd69566d23