### PR TITLE
Raise pack price to $199

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,1 +1,1 @@
-export const PACK_PRICE = 149;
+export const PACK_PRICE = 199;

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -75,9 +75,9 @@ export const en = {
     note: 'Flat pricing. No hidden fees. French-first templates.'
   },
   roi: {
-    title: 'Why <span class="accent">$149</span> beats <span class="accent">~$600–900</span> lost every month',
+    title: 'Why <span class="accent">$199</span> beats <span class="accent">~$600–900</span> lost every month',
     without: 'Lost leads, 3–4 no-shows, late invoices ≈ $600–900/mo',
-    with: 'Pack from $149 → faster replies, fewer no‑shows, invoices on time',
+    with: 'Pack from $199 → faster replies, fewer no‑shows, invoices on time',
     note: 'Many clinics recoup the pack in the first week.',
     disclaimer: 'Estimates based on ~$120–150 per appointment and typical lead leakage in Québec. Results vary.'
   },

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -75,9 +75,9 @@ const fr: TranslationKeys = {
     note: 'Prix fixes. Aucun frais caché. Modèles français d’abord.'
   },
   roi: {
-    title: 'Pourquoi <span class="accent">149 $</span> bat <span class="accent">~600–900 $</span> perdus chaque mois',
+    title: 'Pourquoi <span class="accent">199 $</span> bat <span class="accent">~600–900 $</span> perdus chaque mois',
     without: 'Leads perdus, 3–4 no‑shows, factures en retard ≈ 600–900 $ / mois',
-    with: 'Pack dès 149 $ → réponses plus rapides, moins d’absences, factures à temps',
+    with: 'Pack dès 199 $ → réponses plus rapides, moins d’absences, factures à temps',
     note: 'Beaucoup de cliniques rentabilisent le pack dès la première semaine.',
     disclaimer: 'Estimations basées sur ~120–150 $ par rendez‑vous et des pertes typiques de leads au Québec. Résultats variables.'
   },


### PR DESCRIPTION
## Summary
- update pack price constant and translations from $149 to $199

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5105a0ea48323bd464d9885a993db