### PR TITLE
Limit teal highlighting to titles and compliance checks

### DIFF
--- a/src/components/FinalCTA.tsx
+++ b/src/components/FinalCTA.tsx
@@ -150,9 +150,9 @@ const FinalCTA = () => {
               
               <div className="mt-8 pt-8 border-t border-gray-600 text-center">
                 <p className="text-gray-300 mb-4 text-lg">Or, send a quick question to:</p>
-                <a 
+                <a
                   href="mailto:info@simonparis.ca"
-                  className="inline-flex items-center font-semibold text-lg group transition-colors duration-300 text-[#2280FF] hover:text-teal-400"
+                  className="inline-flex items-center font-semibold text-lg group transition-colors duration-300 text-[#2280FF]"
                 >
                   <Send className="w-5 h-5 mr-2 group-hover:translate-x-1 transition-transform" />
                   info@simonparis.ca

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -65,9 +65,9 @@ const Header = () => {
         }`}>
           <div className="p-6 pt-20">
             <div className="space-y-6">
-              <a 
+              <a
                 href="mailto:info@simonparis.ca"
-                className="block text-white hover:text-teal-400 font-medium"
+                className="block text-white font-medium"
               >
                 info@simonparis.ca
               </a>

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -20,30 +20,30 @@ export const en = {
     },
   problems: {
     title: 'Why clinics <span class="accent">lose money</span> every week…',
-    list: [
-      { title: 'Ignored <span class="accent">leads</span>', body: 'Patients book elsewhere.' },
-      { title: 'Missed <span class="accent">appointments</span>', body: 'Empty chairs at peak hours.' },
-      { title: 'Late <span class="accent">invoices</span>', body: 'Cash flow gets squeezed.' },
-      { title: 'Legal <span class="accent">uncertainty</span>', body: 'Messages may breach Law 25/Bill 96.' }
-    ],
+      list: [
+        { title: 'Ignored leads', body: 'Patients book elsewhere.' },
+        { title: 'Missed appointments', body: 'Empty chairs at peak hours.' },
+        { title: 'Late invoices', body: 'Cash flow gets squeezed.' },
+        { title: 'Legal uncertainty', body: 'Messages may breach Law 25/Bill 96.' }
+      ],
     note: 'You can fix all of this with simple <span class="font-semibold">bilingual automation</span>.'
   },
   growth: {
     title: 'The <span class="accent">growth engine</span> for your clinic: simple, bilingual, compliant.',
     gears: [
-      {
-        title: 'Speed‑to‑Lead <span class="accent">SMS</span>',
-        bullets: ['Replies in under 5 min', 'FR-first, then EN', 'Integrates web, calls, social']
-      },
-      {
-        title: 'No‑Show <span class="accent">Chaser</span> + <span class="accent">Reminders</span>',
-        bullets: ['24h & 2h reminders', 'Easy reschedule link', '25–50% fewer no-shows']
-      },
-      {
-        title: 'Review <span class="accent">Engine</span> + <span class="accent">Compliance</span>',
-        bullets: ['Polite FR/EN review asks', '3× more reviews in 30–60 days', 'Audit-ready docs (Law 25/96)']
-      }
-    ],
+        {
+          title: 'Speed‑to‑Lead SMS',
+          bullets: ['Replies in under 5 min', 'FR-first, then EN', 'Integrates web, calls, social']
+        },
+        {
+          title: 'No‑Show Chaser + Reminders',
+          bullets: ['24h & 2h reminders', 'Easy reschedule link', '25–50% fewer no-shows']
+        },
+        {
+          title: 'Review Engine + Compliance',
+          bullets: ['Polite FR/EN review asks', '3× more reviews in 30–60 days', 'Audit-ready docs (Law 25/96)']
+        }
+      ],
     cta: 'See the packs in action'
   },
   offers: {
@@ -85,12 +85,12 @@ export const en = {
     eyebrow: 'Free',
     title: 'Are you really <span class="accent">Law 25</span> ready?',
     sub: 'Most clinics think they’re fine… until a no-show patient or audit proves otherwise. Download the free checklist to spot the hidden risks in your communication workflows.',
-    points: [
-      'Is your SMS & email <span class="accent">consent wording</span> valid under Québec law?',
-      'Do you have <span class="accent">timestamped proof</span> for every message you send?',
-      'Are your reminders and follow-ups fully <span class="accent">FR-first</span>?',
-      'Can patients <span class="accent">opt-out</span> instantly, without risk of complaint?'
-    ],
+      points: [
+        'Is your SMS & email consent wording valid under Québec law?',
+        'Do you have timestamped proof for every message you send?',
+        'Are your reminders and follow-ups fully FR-first?',
+        'Can patients opt-out instantly, without risk of complaint?'
+      ],
     cta: 'Download the Checklist',
     href: '/checklist',
     disclaimer: 'Free download. Instant access after signup. We’ll also send you practical updates on compliance & automation (unsubscribe anytime).'

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -20,30 +20,30 @@ const fr: TranslationKeys = {
   },
   problems: {
     title: 'Pourquoi les cliniques <span class="accent">perdent de l’argent</span> chaque semaine…',
-    list: [
-      { title: 'Leads <span class="accent">ignorés</span>', body: 'Les patients réservent ailleurs.' },
-      { title: 'Rendez‑vous <span class="accent">manqués</span>', body: 'Des chaises vides aux heures de pointe.' },
-      { title: 'Factures <span class="accent">en retard</span>', body: 'Moins de liquidités chaque mois.' },
-      { title: 'Incertitude <span class="accent">légale</span>', body: 'Risque de non‑conformité (Loi 25/Loi 96).' }
-    ],
+      list: [
+        { title: 'Leads ignorés', body: 'Les patients réservent ailleurs.' },
+        { title: 'Rendez‑vous manqués', body: 'Des chaises vides aux heures de pointe.' },
+        { title: 'Factures en retard', body: 'Moins de liquidités chaque mois.' },
+        { title: 'Incertitude légale', body: 'Risque de non‑conformité (Loi 25/Loi 96).' }
+      ],
     note: 'Tout se corrige avec une <span class="font-semibold">automatisation bilingue</span> simple.'
   },
   growth: {
     title: 'Le <span class="accent">moteur de croissance</span> de votre clinique : simple, bilingue, conforme.',
     gears: [
-      {
-        title: 'SMS <span class="accent">vitesse‑à‑lead</span>',
-        bullets: ['Réponse en moins de 5 min', 'Priorité FR → EN', 'Intégration web, appels, réseaux sociaux']
-      },
-      {
-        title: 'Relance d’<span class="accent">absences</span> + <span class="accent">rappels</span>',
-        bullets: ['Rappels 24 h & 2 h', 'Lien simple pour replanifier', '25–50 % d’absences en moins']
-      },
-      {
-        title: 'Moteur d’<span class="accent">avis</span> + <span class="accent">conformité</span>',
-        bullets: ['Demandes d’avis polies FR/EN', '3× plus d’avis en 30–60 jours', 'Docs prêts pour audit (Loi 25/96)']
-      }
-    ],
+        {
+          title: 'SMS vitesse‑à‑lead',
+          bullets: ['Réponse en moins de 5 min', 'Priorité FR → EN', 'Intégration web, appels, réseaux sociaux']
+        },
+        {
+          title: 'Relance d’absences + rappels',
+          bullets: ['Rappels 24 h & 2 h', 'Lien simple pour replanifier', '25–50 % d’absences en moins']
+        },
+        {
+          title: 'Moteur d’avis + conformité',
+          bullets: ['Demandes d’avis polies FR/EN', '3× plus d’avis en 30–60 jours', 'Docs prêts pour audit (Loi 25/96)']
+        }
+      ],
     cta: 'Voir les packs en action'
   },
   offers: {
@@ -85,12 +85,12 @@ const fr: TranslationKeys = {
     eyebrow: 'Gratuit',
     title: 'Êtes-vous vraiment prêt pour la <span class="accent">Loi 25</span>?',
     sub: 'La plupart des cliniques croient que oui… jusqu’à ce qu’un patient manqué ou un audit révèle le contraire. Téléchargez la liste gratuite pour découvrir les zones à risque dans vos communications.',
-    points: [
-      'Vos <span class="accent">formulaires de consentement</span> pour SMS et courriels sont-ils vraiment conformes?',
-      'Avez-vous une <span class="accent">preuve horodatée</span> de chaque message envoyé?',
-      'Vos rappels et suivis sont-ils 100 % <span class="accent">en français d’abord</span> (FR-first)?',
-      'Vos patients peuvent-ils se <span class="accent">désabonner</span> instantanément, sans plainte possible?'
-    ],
+      points: [
+        'Vos formulaires de consentement pour SMS et courriels sont-ils vraiment conformes?',
+        'Avez-vous une preuve horodatée de chaque message envoyé?',
+        'Vos rappels et suivis sont-ils 100 % en français d’abord (FR-first)?',
+        'Vos patients peuvent-ils se désabonner instantanément, sans plainte possible?'
+      ],
     cta: 'Télécharger la Liste',
     href: '/fr/checklist',
     disclaimer: 'Téléchargement gratuit. Accès immédiat après inscription. Nous vous enverrons aussi des conseils pratiques sur la conformité et l’automatisation (désabonnement en tout temps).'


### PR DESCRIPTION
## Summary
- Remove teal hover styling from header and final CTA links
- Strip accent span wrappers from English and French translation content

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a510d7d14c83238220585e1bce5ab9