### PR TITLE
Fix hover animation delays in section cards

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -310,7 +310,7 @@ const ProblemSection = () => {
               className={`card-light p-6 md:p-8 text-center group transition-all duration-700 ${
                 isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'
               }`}
-              style={{ transitionDelay: `${index * 150}ms` }}
+              style={{ transitionDelay: isVisible ? '0ms' : `${index * 150}ms` }}
             >
               <div className="w-16 h-16 rounded-2xl bg-[#2280FF]/20 flex items-center justify-center mx-auto mb-6 group-hover:scale-110 transition-transform duration-300">
                 <problem.icon className="w-8 h-8 text-[#2280FF]" />
@@ -382,7 +382,7 @@ const GrowthEngine = () => {
               className={`card-light p-6 md:p-8 flex flex-col items-center text-center group transition-all duration-700 ${
                 isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'
               } h-full`}
-              style={{ transitionDelay: `${index * 200}ms` }}
+              style={{ transitionDelay: isVisible ? '0ms' : `${index * 200}ms` }}
             >
               <div className="w-16 h-16 rounded-2xl bg-[#2280FF] flex items-center justify-center mb-6 group-hover:scale-110 transition-transform duration-300">
                 <gear.icon className="w-8 h-8 text-white" />

--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -92,7 +92,7 @@ const Services = () => {
               className={`card-dark p-6 group transition-all duration-700 ${
                 isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'
               }`}
-              style={{ transitionDelay: `${index * 150}ms` }}
+              style={{ transitionDelay: isVisible ? '0ms' : `${index * 150}ms` }}
             >
               <div className="w-16 h-16 rounded-2xl flex items-center justify-center mb-6 group-hover:scale-110 transition-transform duration-300 bg-teal-400">
                 <service.icon className="w-8 h-8 text-white" />

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -92,7 +92,7 @@ const Services = () => {
               className={`card-dark p-6 group transition-all duration-700 ${
                 isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'
               }`}
-              style={{ transitionDelay: `${index * 150}ms` }}
+              style={{ transitionDelay: isVisible ? '0ms' : `${index * 150}ms` }}
             >
               <div className="w-16 h-16 rounded-2xl flex items-center justify-center mb-6 group-hover:scale-110 transition-transform duration-300 bg-teal-400">
                 <service.icon className="w-8 h-8 text-white" />

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -92,7 +92,7 @@ const Services = () => {
               className={`card-dark p-6 group transition-all duration-700 ${
                 isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'
               }`}
-              style={{ transitionDelay: `${index * 150}ms` }}
+              style={{ transitionDelay: isVisible ? '0ms' : `${index * 150}ms` }}
             >
               <div className="w-16 h-16 rounded-2xl flex items-center justify-center mb-6 group-hover:scale-110 transition-transform duration-300 bg-teal-400">
                 <service.icon className="w-8 h-8 text-white" />

--- a/src/components/HowItWorks.tsx
+++ b/src/components/HowItWorks.tsx
@@ -92,7 +92,7 @@ const Services = () => {
               className={`card-dark p-6 group transition-all duration-700 ${
                 isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'
               }`}
-              style={{ transitionDelay: `${index * 150}ms` }}
+              style={{ transitionDelay: isVisible ? '0ms' : `${index * 150}ms` }}
             >
               <div className="w-16 h-16 rounded-2xl flex items-center justify-center mb-6 group-hover:scale-110 transition-transform duration-300 bg-teal-400">
                 <service.icon className="w-8 h-8 text-white" />

--- a/src/components/ProblemSection.tsx
+++ b/src/components/ProblemSection.tsx
@@ -92,7 +92,7 @@ const Services = () => {
               className={`card-dark p-6 group transition-all duration-700 ${
                 isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'
               }`}
-              style={{ transitionDelay: `${index * 150}ms` }}
+              style={{ transitionDelay: isVisible ? '0ms' : `${index * 150}ms` }}
             >
               <div className="w-16 h-16 rounded-2xl flex items-center justify-center mb-6 group-hover:scale-110 transition-transform duration-300 bg-teal-400">
                 <service.icon className="w-8 h-8 text-white" />

--- a/src/components/ProofSection.tsx
+++ b/src/components/ProofSection.tsx
@@ -92,7 +92,7 @@ const Services = () => {
               className={`card-dark p-6 group transition-all duration-700 ${
                 isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'
               }`}
-              style={{ transitionDelay: `${index * 150}ms` }}
+              style={{ transitionDelay: isVisible ? '0ms' : `${index * 150}ms` }}
             >
               <div className="w-16 h-16 rounded-2xl flex items-center justify-center mb-6 group-hover:scale-110 transition-transform duration-300 bg-teal-400">
                 <service.icon className="w-8 h-8 text-white" />

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -92,7 +92,7 @@ const Services = () => {
               className={`card-dark p-6 group transition-all duration-700 ${
                 isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'
               }`}
-              style={{ transitionDelay: `${index * 150}ms` }}
+              style={{ transitionDelay: isVisible ? '0ms' : `${index * 150}ms` }}
             >
               <div className="w-16 h-16 rounded-2xl flex items-center justify-center mb-6 group-hover:scale-110 transition-transform duration-300 bg-teal-400">
                 <service.icon className="w-8 h-8 text-white" />


### PR DESCRIPTION
## Summary
- Reset per-item transition delay to 0 after reveal to keep hover animations responsive
- Apply fix across section components and app grid items

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5116f66f88323b7decb02c37ab534