### PR TITLE
Update ROI copy and remove checklist disclaimer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -545,7 +545,6 @@ const Checklist = () => {
           <a href={t.checklist.href} className="btn-primary px-8 py-4">
             {t.checklist.cta}
           </a>
-          <p className="text-xs text-gray-500 mt-4">{t.checklist.disclaimer}</p>
         </div>
       </div>
     </section>

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -75,7 +75,7 @@ export const en = {
     note: 'Flat pricing. No hidden fees. French-first templates.'
   },
   roi: {
-    title: 'Why <span class="accent">$199</span> beats <span class="accent">~$600–900</span> lost every month',
+    title: '<span class="accent">$199 today</span> saves clinics <span class="accent">~$600–900</span> every month',
     without: 'Lost leads, 3–4 no-shows, late invoices ≈ $600–900/mo',
     with: 'Pack from $199 → faster replies, fewer no‑shows, invoices on time',
     note: 'Many clinics recoup the pack in the first week.',
@@ -92,8 +92,7 @@ export const en = {
       'Can patients <span class="accent">opt-out</span> instantly, without risk of complaint?'
     ],
     cta: 'Download the Checklist',
-    href: '/checklist',
-    disclaimer: 'Free download. Instant access after signup. We’ll also send you practical updates on compliance & automation (unsubscribe anytime).'
+    href: '/checklist'
   },
   proof: {
     title: 'Clinics that automate see results fast.',

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -75,7 +75,7 @@ const fr: TranslationKeys = {
     note: 'Prix fixes. Aucun frais caché. Modèles français d’abord.'
   },
   roi: {
-    title: 'Pourquoi <span class="accent">199 $</span> bat <span class="accent">~600–900 $</span> perdus chaque mois',
+    title: '<span class="accent">199 $</span> pour protéger <span class="accent">600–900 $</span> chaque mois',
     without: 'Leads perdus, 3–4 no‑shows, factures en retard ≈ 600–900 $ / mois',
     with: 'Pack dès 199 $ → réponses plus rapides, moins d’absences, factures à temps',
     note: 'Beaucoup de cliniques rentabilisent le pack dès la première semaine.',
@@ -92,8 +92,7 @@ const fr: TranslationKeys = {
       'Vos patients peuvent-ils se <span class="accent">désabonner</span> instantanément, sans plainte possible?'
     ],
     cta: 'Télécharger la Liste',
-    href: '/fr/checklist',
-    disclaimer: 'Téléchargement gratuit. Accès immédiat après inscription. Nous vous enverrons aussi des conseils pratiques sur la conformité et l’automatisation (désabonnement en tout temps).'
+    href: '/fr/checklist'
   },
   proof: {
     title: 'Les cliniques qui automatisent voient des résultats rapides.',


### PR DESCRIPTION
## Summary
- Update ROI headline to emphasize $199 monthly savings in English and French.
- Remove sign-up disclaimer from checklist translations and UI.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a51256f6988323b7ba3b35b0b598b4