### PR TITLE
Simplify ROI section with bilingual hero copy

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -471,7 +471,7 @@ const OfferCards = () => {
 const ROIMath = () => {
   const [isVisible, setIsVisible] = useState(false);
   const sectionRef = useRef<HTMLElement>(null);
-  const { t, lang } = useLanguage();
+  const { t } = useLanguage();
 
   useEffect(() => {
     const observer = new IntersectionObserver(([entry]) => {
@@ -491,25 +491,12 @@ const ROIMath = () => {
     <section ref={sectionRef} className="relative py-16 lg:py-20 overflow-hidden" style={{ background: '#F9FAFB' }}>
       <div className="relative z-10 max-w-5xl mx-auto px-6 lg:px-8 text-center">
         <div className={`mb-12 transition-all duration-1000 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}>
-          <h2
-            className="text-display text-gray-900 mb-6"
-            dangerouslySetInnerHTML={{ __html: t.roi.title }}
-          />
+          <h2 className="text-display text-gray-900 font-bold mb-4">
+            {t.roi.title}
+          </h2>
+          <p className="text-gray-700">{t.roi.sub}</p>
+          <p className="text-gray-700 text-xs mt-4">{t.roi.footnote}</p>
         </div>
-
-        <div className={`grid md:grid-cols-2 gap-8 transition-all duration-1000 delay-200 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}>
-          <div className="card-light p-6 md:p-8">
-            <h3 className="text-xl font-semibold text-gray-900 mb-2">{lang === 'fr' ? 'Sans automatisation' : 'Without automation'}</h3>
-            <p className="text-gray-700">{t.roi.without}</p>
-          </div>
-          <div className="card-light p-6 md:p-8">
-            <h3 className="text-xl font-semibold text-gray-900 mb-2">{lang === 'fr' ? 'Avec automatisation' : 'With automation'}</h3>
-            <p className="text-gray-700">{t.roi.with}</p>
-          </div>
-        </div>
-
-        <p className="text-gray-700 mt-8">{t.roi.note}</p>
-        <p className="text-gray-700 text-xs mt-2">{t.roi.disclaimer}</p>
       </div>
     </section>
   );

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -74,11 +74,9 @@ export const en = {
     note: 'Flat pricing. No hidden fees. French-first templates.'
   },
   roi: {
-    title: '<span class="accent">$199 today</span> saves clinics <span class="accent">~$600–900</span> every month',
-    without: 'Lost leads, 3–4 no-shows, late invoices ≈ $600–900/mo',
-    with: 'Pack from $199 → faster replies, fewer no‑shows, invoices on time',
-    note: 'Many clinics recoup the pack in the first week.',
-    disclaimer: 'Estimates based on ~$120–150 per appointment and typical lead leakage in Québec. Results vary.'
+    title: `💡 “Each pack starts at just $${PACK_PRICE} — most clinics add 2–3 for best results.”`,
+    sub: 'Clinics typically recover $600–900/month in lost leads, no-shows, and admin hours — plus fewer headaches and happier staff.',
+    footnote: 'Estimates based on ~$120–150 per appointment and typical lead leakage in Québec. Results vary.'
   },
   checklist: {
     eyebrow: 'Free',

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -74,11 +74,9 @@ const fr: TranslationKeys = {
     note: 'Prix fixes. Aucun frais caché. Modèles français d’abord.'
   },
   roi: {
-    title: '<span class="accent">199 $</span> pour protéger <span class="accent">600–900 $</span> chaque mois',
-    without: 'Leads perdus, 3–4 no‑shows, factures en retard ≈ 600–900 $ / mois',
-    with: 'Pack dès 199 $ → réponses plus rapides, moins d’absences, factures à temps',
-    note: 'Beaucoup de cliniques rentabilisent le pack dès la première semaine.',
-    disclaimer: 'Estimations basées sur ~120–150 $ par rendez‑vous et des pertes typiques de leads au Québec. Résultats variables.'
+    title: `💡 « Chaque module commence à seulement ${PACK_PRICE} $ — la plupart des cliniques en ajoutent 2 ou 3 pour de vrais résultats. »`,
+    sub: 'Les cliniques récupèrent généralement 600 à 900 $/mois en rendez-vous sauvés, moins d’absences et moins de tâches administratives — tout en réduisant le stress de l’équipe.',
+    footnote: 'Estimations basées sur ~120 à 150 $ par rendez-vous et les pertes de clients typiques au Québec. Les résultats peuvent varier.'
   },
   checklist: {
     eyebrow: 'Gratuit',


### PR DESCRIPTION
## Summary
- replace ROI hero copy with single bilingual headline and supporting text
- remove with/without automation boxes
- update English and French translations for new pricing message

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a62b0650a883238c6ae50a4447be30