### PR TITLE
fix: normalize landing page routing

### DIFF
--- a/src/LanguageProvider.tsx
+++ b/src/LanguageProvider.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import { translations, Language, Translation } from './i18n';
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
@@ -7,7 +8,8 @@ import { LandingEN, LandingFR } from './pages/SpeedToLead';
 import { LanguageProvider } from './LanguageProvider';
 import './index.css';
 
-const path = window.location.pathname;
+// Normalize path to handle optional trailing slashes and encoded characters
+const path = decodeURI(window.location.pathname).replace(/\/+$/, '') || '/';
 let Component = App;
 if (path === '/privacy') {
   Component = PrivacyPolicy;


### PR DESCRIPTION
## Summary
- decode and normalize URLs before routing to ensure Speed-to-Lead pages render
- silence react-refresh lint rule in entry points

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a91954adf48323ada45dd9daba1aa1