### PR TITLE
Add Loi 25 compliance checklist page

### DIFF
--- a/fr/ressources/liste-conformite-loi25-96/index.html
+++ b/fr/ressources/liste-conformite-loi25-96/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="fr-CA">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Conformité Loi 25 — Simon Paris</title>
+    <link rel="canonical" href="https://simonparis.ca/fr/ressources/liste-conformite-loi25-96" />
+    <link rel="alternate" hreflang="fr-CA" href="https://simonparis.ca/fr/ressources/liste-conformite-loi25-96" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="../../../src/main.tsx"></script>
+  </body>
+</html>

--- a/src/components/LeadMagnet.tsx
+++ b/src/components/LeadMagnet.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+
+interface LeadMagnetProps {
+  title: string;
+  subtitle?: string;
+  bullets: string[];
+  imageSrc: string;
+  consent: React.ReactNode;
+  ctaText: string;
+  person: {
+    name: string;
+    title: string;
+    imageSrc: string;
+  };
+}
+
+const LeadMagnet: React.FC<LeadMagnetProps> = ({
+  title,
+  subtitle,
+  bullets,
+  imageSrc,
+  consent,
+  ctaText,
+  person,
+}) => {
+  return (
+    <div className="min-h-screen bg-gray-100 flex flex-col items-center justify-center p-4 lg:p-8">
+      <div className="w-full max-w-5xl mx-auto">
+        <div className="bg-white lg:grid lg:grid-cols-2 shadow-2xl rounded-2xl overflow-hidden">
+          <div className="hidden lg:block relative">
+            <img src={imageSrc} alt="" className="w-full h-full object-cover" />
+          </div>
+          <div className="p-8 md:p-12">
+            <div className="lg:hidden mb-6">
+              <img
+                src={imageSrc}
+                alt=""
+                className="w-full h-auto object-cover rounded-lg"
+              />
+            </div>
+            <h1 className="text-2xl lg:text-3xl font-bold text-[#121C2D] leading-tight">
+              {title}
+            </h1>
+            {subtitle && (
+              <p className="mt-2 text-sm text-gray-500">{subtitle}</p>
+            )}
+            <ul className="mt-6 space-y-3 text-gray-500">
+              {bullets.map(item => (
+                <li key={item} className="flex items-start">
+                  <svg
+                    className="h-6 w-6 text-teal-400 flex-shrink-0 mr-3 mt-0.5"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M5 13l4 4L19 7"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+            <div className="mt-8">
+              <form action="#" method="POST">
+                <div className="space-y-4">
+                  <div>
+                    <label htmlFor="name" className="sr-only">
+                      Nom complet
+                    </label>
+                    <input
+                      id="name"
+                      name="name"
+                      type="text"
+                      required
+                      placeholder="Nom complet"
+                      className="block w-full px-4 py-3 border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-teal-400"
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="email" className="sr-only">
+                      Adresse e-mail
+                    </label>
+                    <input
+                      id="email"
+                      name="email"
+                      type="email"
+                      required
+                      placeholder="Adresse e-mail"
+                      className="block w-full px-4 py-3 border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-teal-400"
+                    />
+                  </div>
+                </div>
+                <div className="mt-5">
+                  <label className="flex items-start">
+                    <input
+                      type="checkbox"
+                      className="h-4 w-4 text-teal-400 border-gray-300 rounded focus:ring-teal-400 mt-0.5"
+                    />
+                    <span className="ml-3 text-xs text-gray-500">{consent}</span>
+                  </label>
+                </div>
+                <button
+                  type="submit"
+                  className="mt-6 w-full flex justify-center items-center py-4 px-4 border border-transparent rounded-lg shadow-sm text-base font-bold text-white bg-teal-400 hover:bg-[#108482] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-teal-400 transition duration-150 ease-in-out"
+                >
+                  {ctaText}
+                </button>
+              </form>
+              <p className="mt-5 text-center text-sm font-medium text-gray-500">
+                ✔ Recommandé par des PME du Québec.
+              </p>
+              <div className="mt-8 pt-6 border-t border-gray-200 flex items-center">
+                <img
+                  src={person.imageSrc}
+                  alt={person.name}
+                  className="h-14 w-14 rounded-full object-cover"
+                />
+                <div className="ml-4">
+                  <p className="font-bold text-[#121C2D]">{person.name}</p>
+                  <p className="text-sm text-gray-500">{person.title}</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LeadMagnet;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import App from './App.tsx';
 import PrivacyPolicy from './pages/PrivacyPolicy';
 import PolitiqueConfidentialite from './pages/PolitiqueConfidentialite';
 import { LandingEN, LandingFR } from './pages/SpeedToLead';
+import Loi25Checklist from './pages/Loi25Checklist';
 import { LanguageProvider } from './LanguageProvider';
 import './index.css';
 
@@ -19,6 +20,8 @@ if (path === '/privacy') {
   Component = LandingEN;
 } else if (path === '/fr/ne-manquez-aucun-patient') {
   Component = LandingFR;
+} else if (path === '/fr/ressources/liste-conformite-loi25-96') {
+  Component = Loi25Checklist;
 }
 
 createRoot(document.getElementById('root')!).render(

--- a/src/pages/Loi25Checklist.tsx
+++ b/src/pages/Loi25Checklist.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import LeadMagnet from '../components/LeadMagnet';
+
+const heroImg =
+  'https://lh3.googleusercontent.com/aida-public/AB6AXuBEhtKecyFcExEW7tPdHHPhRyttcqxBIYtE6viQ9uYtSl0f6YjUYjrn4U-' +
+  '3H8ltPS8C5HxGMj987DgDTv5F7CAnEYTKidkOWY4XmuKiY7gYFGEDoRBq5IQXmBHdMOGMSnCenxaKqWFyifcQZZq-ae0Fzl-X8-UkO5krlwNKYJ1SmU56KH30Oj77qf1' +
+  'JAw8x2e9SK2WPfEZFxyq6QNwy5usrRnb2pjdTBHAR6P1zeWr1r9LyAuAKlg46JGdFkUJUPbGtbNM7u1lhWEw';
+
+const avatarImg =
+  'https://lh3.googleusercontent.com/aida-public/AB6AXuDBvThyq2HHeUHfEJ6lHaZM8dDc87KlBDib-FfJs11lqjxqaS7e7qh7nYk15ZDb2bmjCoMWaigvUHezQ19ShmjSPXWHmBq_9ibtrnoVfuqmU_' +
+  'bAR4GjL6ZonoRJBDHvREjB6NdLyW-RaGuCyGOwNvHC5GT0LBi9lFVH0fK3P6WA2CWYaM2M9jKttHs6Go1XMOOr9unF_pB2k2UzCUMM5bXpPRTsd4QR5BDKuvlwdrdzki8lpIefEH9s2D8W-' +
+  'aj6mRzpHft3DI7tmJE';
+
+const Loi25Checklist: React.FC = () => {
+  return (
+    <LeadMagnet
+      title="Le guide essentiel pour rester conforme à la Loi 25 — sans perdre de temps."
+      bullets={[
+        'Découvrez les 3 obligations clés que chaque PME québécoise doit respecter dès maintenant.',
+        'Évitez les amendes coûteuses grâce à une liste de vérification claire.',
+        'Gagnez du temps grâce à des actions prêtes à appliquer immédiatement.',
+      ]}
+      imageSrc={heroImg}
+      ctaText="Télécharger le guide gratuit"
+      consent="J’accepte de recevoir aussi des communications par courriel concernant la conformité et l’automatisation (Loi 25). Je peux me désabonner en tout temps."
+      person={{
+        name: 'Simon Paris',
+        title: 'Conseiller en automatisation – Québec',
+        imageSrc: avatarImg,
+      }}
+    />
+  );
+};
+
+export default Loi25Checklist;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,6 +21,10 @@ export default defineConfig({
           __dirname,
           'never-miss-a-patient/index.html'
         ),
+        frLoi25Checklist: resolve(
+          __dirname,
+          'fr/ressources/liste-conformite-loi25-96/index.html'
+        ),
       },
     },
   },


### PR DESCRIPTION
## Summary
- replace static Loi 25 checklist HTML with a React page powered by a reusable LeadMagnet component
- register the checklist route in the app router and include it in the Vite build outputs
- remove all English text so the checklist page is entirely French
- use the same Simon portrait for the checklist hero and author avatar
- revert to the original checklist hero image and use a new portrait for the author avatar
- drop the local binary avatar and reference external images instead

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf8313b93883238a97a57a89cd4ac2