### PR TITLE
Add bilingual Brevo newsletter signup pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import PartnerBar from './components/PartnerBar';
 const Hero = () => {
   const { t } = useLanguage();
   const isFR = typeof window !== 'undefined' && window.location.pathname.startsWith('/fr');
-  const base = isFR ? '/fr' : '';
+  const newsletterHref = isFR ? '/fr/newsletter' : '/en/newsletter';
 
   return (
     <section
@@ -44,10 +44,10 @@ const Hero = () => {
 
         <div className="flex justify-center">
           <a
-            href={`${base}/checklist`}
+            href={newsletterHref}
             className="btn-primary text-lg px-8 py-4"
             data-event="cta_click"
-            data-cta="checklist"
+            data-cta="newsletter"
           >
             {t.hero.primaryCta}
           </a>
@@ -135,7 +135,7 @@ const GrowthEngine = () => {
   const [isVisible, setIsVisible] = useState(false);
   const sectionRef = useRef<HTMLElement>(null);
   const { t, lang } = useLanguage();
-  const base = lang === 'fr' ? '/fr' : '';
+  const newsletterHref = lang === 'fr' ? '/fr/newsletter' : '/en/newsletter';
 
   useEffect(() => {
     const observer = new IntersectionObserver(
@@ -211,7 +211,7 @@ const OfferCards = () => {
   const [isVisible, setIsVisible] = useState(false);
   const sectionRef = useRef<HTMLElement>(null);
   const { t, lang } = useLanguage();
-  const base = lang === 'fr' ? '/fr' : '';
+  const newsletterHref = lang === 'fr' ? '/fr/newsletter' : '/en/newsletter';
 
   useEffect(() => {
     const observer = new IntersectionObserver(
@@ -316,7 +316,7 @@ const ROIMath = () => {
 // Checklist Component
 const Checklist = () => {
   const { t, lang } = useLanguage();
-  const base = lang === 'fr' ? '/fr' : '';
+  const newsletterHref = lang === 'fr' ? '/fr/newsletter' : '/en/newsletter';
   return (
     <section className="relative py-16 lg:py-20 overflow-hidden" style={{ background: '#FFFFFF' }}>
       <div className="relative z-10 max-w-5xl mx-auto px-6 lg:px-8">
@@ -338,7 +338,14 @@ const Checklist = () => {
               </li>
             ))}
           </ul>
-          <a href={`${base}${t.checklist.href}`} className="btn-primary px-8 py-4">
+            <a
+              href={
+                t.checklist.href.startsWith('/fr') || t.checklist.href.startsWith('/en')
+                  ? t.checklist.href
+                  : newsletterHref
+              }
+              className="btn-primary px-8 py-4"
+            >
             {t.checklist.cta}
           </a>
         </div>
@@ -466,6 +473,8 @@ const FAQ = () => {
 const FinalCTA = () => {
   const { t, lang } = useLanguage();
   const base = lang === 'fr' ? '/fr' : '';
+  const resolveHref = (path: string) =>
+    path.startsWith('/fr') || path.startsWith('/en') ? path : `${base}${path}`;
 
   return (
     <section className="relative py-16 bg-[#121C2D] text-center text-white">
@@ -473,10 +482,10 @@ const FinalCTA = () => {
         <h2 className="text-3xl font-bold mb-4">{t.finalCTA.title}</h2>
         <p className="text-lg text-white/80 mb-8">{t.finalCTA.sub}</p>
         <div className="flex flex-col sm:flex-row gap-4 justify-center">
-          <a href={`${base}${t.finalCTA.primaryHref}`} className="btn-primary px-8 py-4">
+          <a href={resolveHref(t.finalCTA.primaryHref)} className="btn-primary px-8 py-4">
             {t.finalCTA.primary}
           </a>
-          <a href={`${base}${t.finalCTA.secondaryHref}`} className="btn-outline text-lg px-8 py-4">
+          <a href={resolveHref(t.finalCTA.secondaryHref)} className="btn-outline text-lg px-8 py-4">
             {t.finalCTA.secondary}
           </a>
         </div>
@@ -496,10 +505,10 @@ const StickyCTA = () => {
   }, []);
 
   if (!visible) return null;
-  const base = lang === 'fr' ? '/fr' : '';
+  const newsletterHref = lang === 'fr' ? '/fr/newsletter' : '/en/newsletter';
   return (
     <div className="sticky-cta md:hidden">
-      <a href={`${base}/checklist`} className="btn-primary w-full text-lg py-4">
+      <a href={newsletterHref} className="btn-primary w-full text-lg py-4">
         {t.stickyCta}
       </a>
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -135,7 +135,7 @@ const GrowthEngine = () => {
   const [isVisible, setIsVisible] = useState(false);
   const sectionRef = useRef<HTMLElement>(null);
   const { t, lang } = useLanguage();
-  const newsletterHref = lang === 'fr' ? '/fr/newsletter' : '/en/newsletter';
+  const base = lang === 'fr' ? '/fr' : '';
 
   useEffect(() => {
     const observer = new IntersectionObserver(
@@ -211,7 +211,7 @@ const OfferCards = () => {
   const [isVisible, setIsVisible] = useState(false);
   const sectionRef = useRef<HTMLElement>(null);
   const { t, lang } = useLanguage();
-  const newsletterHref = lang === 'fr' ? '/fr/newsletter' : '/en/newsletter';
+  const base = lang === 'fr' ? '/fr' : '';
 
   useEffect(() => {
     const observer = new IntersectionObserver(

--- a/src/LanguageProvider.tsx
+++ b/src/LanguageProvider.tsx
@@ -15,22 +15,26 @@ const LanguageContext = createContext<LangContext>({
 });
 
 const detectLanguage = async (): Promise<Language> => {
-  const navLang = navigator.language || (navigator.languages && navigator.languages[0]);
-  if (navLang) {
-    const lower = navLang.toLowerCase();
-    if (lower.startsWith('fr')) return 'fr';
-    if (lower.startsWith('en')) return 'en';
-  }
-  try {
-    const res = await fetch('https://ipapi.co/json/');
-    if (res.ok) {
-      const data = await res.json();
-      if (data && data.region_code === 'QC') {
-        return 'fr';
-      }
+  if (typeof navigator !== 'undefined') {
+    const navLang = navigator.language || (navigator.languages && navigator.languages[0]);
+    if (navLang) {
+      const lower = navLang.toLowerCase();
+      if (lower.startsWith('fr')) return 'fr';
+      if (lower.startsWith('en')) return 'en';
     }
-  } catch {
-    // ignore network errors
+  }
+  if (typeof fetch === 'function') {
+    try {
+      const res = await fetch('https://ipapi.co/json/');
+      if (res.ok) {
+        const data = await res.json();
+        if (data && data.region_code === 'QC') {
+          return 'fr';
+        }
+      }
+    } catch {
+      // ignore network errors
+    }
   }
   return 'en';
 };
@@ -41,13 +45,17 @@ export const LanguageProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   const [lang, setLang] = useState<Language>(pathLang);
 
   useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
     const currentPathLang = window.location.pathname.startsWith('/fr') ? 'fr' : null;
     if (currentPathLang) {
       setLang(currentPathLang);
-      localStorage.setItem('lang', currentPathLang);
+      window.localStorage.setItem('lang', currentPathLang);
       return;
     }
-    const stored = localStorage.getItem('lang') as Language | null;
+    const stored = window.localStorage.getItem('lang') as Language | null;
     if (stored) {
       setLang(stored);
       return;
@@ -56,7 +64,10 @@ export const LanguageProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   }, []);
 
   useEffect(() => {
-    localStorage.setItem('lang', lang);
+    if (typeof window === 'undefined') {
+      return;
+    }
+    window.localStorage.setItem('lang', lang);
   }, [lang]);
 
   return (

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -6,7 +6,8 @@ export const Header: React.FC<{
   langToggle?: { fr: string; en: string };
   ctaHref?: string;
   ctaLabel?: string;
-}> = ({ langToggle, ctaHref, ctaLabel }) => {
+  forceDarkBackground?: boolean;
+}> = ({ langToggle, ctaHref, ctaLabel, forceDarkBackground }) => {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
   const { t, lang, setLang } = useLanguage();
@@ -24,7 +25,13 @@ export const Header: React.FC<{
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
-  const textClass = !isScrolled && isPrivacyPage ? 'text-[#121C2D]' : 'text-white';
+  const resolvedTextClass = forceDarkBackground
+    ? 'text-white'
+    : !isScrolled && isPrivacyPage
+    ? 'text-[#121C2D]'
+    : 'text-white';
+  const textClass = resolvedTextClass;
+  const navLinkHoverClass = forceDarkBackground ? 'hover:text-white' : 'hover:text-[#2280FF]';
   const base = lang === 'fr' ? '/fr' : '';
 
   const LanguageToggle = ({ className }: { className?: string }) => {
@@ -46,19 +53,23 @@ export const Header: React.FC<{
     );
   };
 
+  const headerBackgroundClass = forceDarkBackground
+    ? 'bg-[#121C2D]'
+    : isScrolled
+    ? 'bg-[#121C2D]'
+    : 'bg-transparent';
+
   return (
     <>
       <header
-        className={`fixed top-0 left-0 right-0 z-50 transition-colors duration-500 ${
-          isScrolled ? 'bg-[#121C2D]' : 'bg-transparent'
-        }`}
+        className={`fixed top-0 left-0 right-0 z-50 transition-colors duration-500 ${headerBackgroundClass}`}
       >
         <div className="max-w-7xl mx-auto px-6 lg:px-8">
           <div className="flex justify-between items-center py-4">
             <a
               href={lang === 'fr' ? '/fr' : '/'}
               onClick={() => localStorage.setItem('lang', lang)}
-              className={`text-2xl font-bold ${textClass}`}
+              className={`text-2xl font-bold ${resolvedTextClass}`}
             >
               {t.header.brand}
             </a>
@@ -66,7 +77,7 @@ export const Header: React.FC<{
               <LanguageToggle />
               <a
                 href={`mailto:${t.header.email}`}
-                className={`transition-colors duration-300 font-medium ${textClass} hover:text-[#2280FF]`}
+                className={`transition-colors duration-300 font-medium ${resolvedTextClass} ${navLinkHoverClass}`}
               >
                 {t.header.email}
               </a>
@@ -78,9 +89,9 @@ export const Header: React.FC<{
               <LanguageToggle />
               <button onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}>
                 {isMobileMenuOpen ? (
-                  <X className={`w-6 h-6 ${textClass}`} />
+                  <X className={`w-6 h-6 ${resolvedTextClass}`} />
                 ) : (
-                  <Menu className={`w-6 h-6 ${textClass}`} />
+                  <Menu className={`w-6 h-6 ${resolvedTextClass}`} />
                 )}
               </button>
             </div>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -31,8 +31,9 @@ export const Header: React.FC<{
     ? 'text-[#121C2D]'
     : 'text-white';
   const textClass = resolvedTextClass;
-  const navLinkHoverClass = forceDarkBackground ? 'hover:text-white' : 'hover:text-[#2280FF]';
-  const base = lang === 'fr' ? '/fr' : '';
+  const newsletterHref = lang === 'fr' ? '/fr/newsletter' : '/en/newsletter';
+  const resolvedCtaHref = ctaHref ?? newsletterHref;
+  const resolvedCtaLabel = ctaLabel ?? t.header.cta;
 
   const LanguageToggle = ({ className }: { className?: string }) => {
     const otherLang = lang === 'fr' ? 'en' : 'fr';
@@ -75,14 +76,8 @@ export const Header: React.FC<{
             </a>
             <div className="hidden md:flex items-center space-x-8">
               <LanguageToggle />
-              <a
-                href={`mailto:${t.header.email}`}
-                className={`transition-colors duration-300 font-medium ${resolvedTextClass} ${navLinkHoverClass}`}
-              >
-                {t.header.email}
-              </a>
-              <a href={ctaHref ?? `${base}/checklist`} className="btn-primary text-sm px-6 py-3">
-                {ctaLabel ?? t.header.cta}
+              <a href={resolvedCtaHref} className="btn-primary text-sm px-6 py-3">
+                {resolvedCtaLabel}
               </a>
             </div>
             <div className="flex md:hidden items-center space-x-4">
@@ -116,14 +111,8 @@ export const Header: React.FC<{
         >
           <div className="p-6 pt-20 space-y-6 text-center">
             <LanguageToggle className="text-[#121C2D]" />
-            <a
-              href={`mailto:${t.header.email}`}
-              className="block text-[#121C2D] hover:text-[#2280FF] font-medium"
-            >
-              {t.header.email}
-            </a>
-            <a href={ctaHref ?? `${base}/checklist`} className="btn-primary w-full">
-              {ctaLabel ?? t.header.cta}
+            <a href={resolvedCtaHref} className="btn-primary w-full">
+              {resolvedCtaLabel}
             </a>
           </div>
         </div>

--- a/src/components/SignupForm.tsx
+++ b/src/components/SignupForm.tsx
@@ -64,13 +64,13 @@ export const SignupForm: React.FC<SignupFormProps> = ({ lang }) => {
   return (
     <>
       <section className="w-full font-inter">
-        <div className="mx-auto w-full max-w-[540px] rounded-[12px] bg-white/95 p-8 shadow-[0_32px_80px_rgba(18,28,45,0.12)] ring-1 ring-black/5 sm:p-12">
-          <header className="mb-12 space-y-4 md:space-y-5">
+        <div className="mx-auto w-full max-w-[540px] rounded-[12px] bg-white p-8 shadow-[0_32px_80px_rgba(18,28,45,0.12)] ring-1 ring-black/5 sm:p-12">
+          <header className="mb-10 space-y-3 md:mb-12 md:space-y-4">
             <h1 className="text-3xl font-semibold text-[#121C2D] md:text-4xl">{copy.title}</h1>
             <p className="text-lg font-semibold text-[#139E9C] md:text-xl">{copy.subtitle}</p>
-            <div className="space-y-2">
+            <div className="space-y-1.5">
               {bodyLines.map(line => (
-                <p key={line} className="text-base leading-relaxed text-[#4B5563]">
+                <p key={line} className="text-sm leading-relaxed text-[#4B5563] md:text-base">
                   {line}
                 </p>
               ))}
@@ -82,7 +82,7 @@ export const SignupForm: React.FC<SignupFormProps> = ({ lang }) => {
             data-type="subscription"
             method="POST"
             action={POST_URL}
-            className="space-y-9"
+            className="space-y-8"
           >
             <div className="space-y-2">
               <label htmlFor="EMAIL" className="text-sm font-semibold text-[#1F2937]">

--- a/src/components/SignupForm.tsx
+++ b/src/components/SignupForm.tsx
@@ -1,43 +1,41 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState, useId } from 'react';
 
 const POST_URL =
   'https://c454d84b.sibforms.com/serve/MUIFAH7NOSykJlqeKP4c-jXRt7b-0MCgSB0R8BROAkZEQAbRZUO09B2nZUBGX-BfJqMMUURc1KBYeqGz7QduVv9MMy4fEEABw-5k98uGvJ18IAljU5oid79WFyl5-fBS2v5Ng8XlZEx7u7IZ9Dp6gCdZaTRY9trZH1U_GfpFHWxUpo0yvGpQR3DlmKDky65MJJvyhZoT0t1GbEkE';
-const RECAPTCHA_SITE_KEY = '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI';
+const RECAPTCHA_SITE_KEY = '6Lf0RtYrAAAAAMnsVvJx3DTeKDVGi2ZQElXygdM-';
 
 const copy = {
   fr: {
     heading: 'Infolettre PME Québec',
-    intro:
-      'Recevez des tactiques concrètes d\'automatisation et d\'IA pour les PME québécoises. Un courriel 2x par mois, sans spam.',
-    emailLabel: 'Adresse courriel',
-    emailPlaceholder: 'nom@entreprise.com',
+    subheading: 'Automatisation et IA pour dirigeants pressés',
+    body:
+      'Deux fois par mois, recevez des tactiques applicables pour gagner du temps, éviter des erreurs coûteuses et rester conforme à la Loi 25 — sans blabla.',
+    emailLabel: 'Adresse courriel professionnelle',
+    emailPlaceholder: 'prenom.nom@entreprise.com',
     consentLabel:
-      "J'accepte de recevoir des communications de The Automated SMB et je peux me désabonner en tout temps.",
-    submit: "Je m'inscris",
-    consentNote: 'Nous respectons la Loi 25 et la Loi anti-pourriel (LCAP).',
+      "Je consens à recevoir les communications de The Automated SMB et comprends que je pourrai me désabonner en tout temps.",
+    consentNote: 'Vos données sont traitées au Québec et conformes à la Loi 25 et à la LCAP.',
+    submit: "Recevoir l'infolettre",
     successTitle: 'Merci! Votre inscription est confirmée.',
-    successBody: 'Vérifiez vos courriels pour le message de bienvenue.',
+    successBody: 'Vérifiez votre boîte de réception pour le courriel de bienvenue.',
     errorTitle: "Oups! Une erreur est survenue.",
-    errorBody: 'Veuillez réessayer ou nous écrire à hello@simonparis.ca.',
-    toggleLabel: 'Version anglaise',
-    toggleHref: '/en/newsletter'
+    errorBody: 'Veuillez réessayer ou nous écrire à hello@simonparis.ca.'
   },
   en: {
     heading: 'Québec SMB AI Newsletter',
-    intro:
-      'Get bilingual automation playbooks for Québec SMEs. Twice-monthly insights—actionable, no fluff.',
-    emailLabel: 'Email address',
-    emailPlaceholder: 'name@company.com',
+    subheading: 'Automation guidance for owners who move fast',
+    body:
+      'Every two weeks, receive concise playbooks that save hours, prevent costly mistakes, and keep your team compliant with Law 25 — no fluff.',
+    emailLabel: 'Business email address',
+    emailPlaceholder: 'firstname.lastname@company.com',
     consentLabel:
-      'I agree to receive communications from The Automated SMB and understand I can unsubscribe anytime.',
-    submit: 'Subscribe now',
-    consentNote: 'Fully compliant with Law 25 and Canada\'s Anti-Spam Legislation.',
-    successTitle: 'Thanks! You are on the list.',
-    successBody: 'Check your inbox for the welcome email.',
+      'I consent to receive communications from The Automated SMB and understand I can unsubscribe at any time.',
+    consentNote: "Your data is handled in Québec and compliant with Law 25 and Canada's Anti-Spam Legislation.",
+    submit: 'Join the newsletter',
+    successTitle: "Thanks! You're on the list.",
+    successBody: 'Look for the welcome email in your inbox within a few minutes.',
     errorTitle: 'Oops! Something went wrong.',
-    errorBody: 'Please try again or email hello@simonparis.ca.',
-    toggleLabel: 'Version française',
-    toggleHref: '/fr/newsletter'
+    errorBody: 'Please try again or email hello@simonparis.ca.'
   }
 } as const;
 
@@ -68,13 +66,13 @@ const ensureHeadScript = (selector: string, create: () => HTMLScriptElement) => 
 export const SignupForm: React.FC<SignupFormProps> = ({ lang }) => {
   const t = copy[lang];
   const [sourceUrl, setSourceUrl] = useState('');
+  const emailFieldId = useId();
+  const consentFieldId = useId();
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
     setSourceUrl(window.location.href);
   }, []);
-
-  const localeValue = useMemo(() => lang, [lang]);
 
   useEffect(() => {
     if (typeof document === 'undefined') return;
@@ -90,6 +88,7 @@ export const SignupForm: React.FC<SignupFormProps> = ({ lang }) => {
       const script = document.createElement('script');
       script.src = 'https://sibforms.com/forms/end-form/build/main.js';
       script.defer = true;
+      script.async = true;
       script.dataset.brevo = 'main';
       return script;
     });
@@ -113,78 +112,79 @@ export const SignupForm: React.FC<SignupFormProps> = ({ lang }) => {
       const script = document.createElement('script');
       script.src = scriptSrc;
       script.defer = true;
+      script.async = true;
       script.dataset.recaptcha = 'loader';
       return script;
     });
   }, [lang]);
 
+  const localeValue = useMemo(() => lang, [lang]);
+
   return (
-    <div className="bg-white shadow-xl rounded-3xl p-8 md:p-12 border border-slate-200">
-      <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-6 mb-10">
-        <div className="space-y-3 text-center md:text-left">
-          <p className="text-sm uppercase tracking-widest text-[#2280FF]/80 font-semibold">The Automated SMB</p>
-          <h1 className="text-3xl md:text-4xl font-bold text-[#121C2D]">{t.heading}</h1>
-          <p className="text-base md:text-lg text-slate-600 leading-relaxed">{t.intro}</p>
-        </div>
-        <a
-          href={t.toggleHref}
-          className="self-center md:self-start inline-flex items-center px-4 py-2 rounded-full border border-[#2280FF] text-[#2280FF] font-medium hover:bg-[#2280FF]/10 transition"
-        >
-          {t.toggleLabel}
-        </a>
+    <section className="relative">
+      <div className="absolute inset-0 -z-10 rounded-[32px] bg-gradient-to-br from-slate-100 via-white to-slate-100" />
+      <div className="relative mx-auto max-w-[600px] rounded-[32px] border border-slate-200 bg-white/90 p-10 shadow-[0_25px_55px_rgba(18,28,45,0.12)] backdrop-blur">
+        <header className="mb-10 space-y-4 text-center md:text-left">
+          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-500">The Automated SMB</p>
+          <h1 className="text-3xl font-semibold text-slate-900 md:text-4xl">{t.heading}</h1>
+          <p className="text-lg font-medium text-slate-600">{t.subheading}</p>
+          <p className="text-base leading-relaxed text-slate-600">{t.body}</p>
+        </header>
+
+        <form method="POST" action={POST_URL} className="space-y-6" noValidate>
+          <div className="space-y-2">
+            <label htmlFor={emailFieldId} className="text-sm font-semibold text-slate-700">
+              {t.emailLabel}
+            </label>
+            <input
+              id={emailFieldId}
+              name="EMAIL"
+              type="email"
+              required
+              placeholder={t.emailPlaceholder}
+              className="w-full rounded-2xl border border-slate-300 bg-white px-5 py-4 text-base text-slate-900 shadow-sm transition focus:border-[#2280FF] focus:outline-none focus:ring-4 focus:ring-[#2280FF]/20"
+            />
+          </div>
+
+          <div className="flex items-start gap-3 rounded-2xl bg-slate-50/80 p-4">
+            <input
+              id={consentFieldId}
+              name="OPT_IN"
+              type="checkbox"
+              required
+              className="mt-1 h-5 w-5 rounded border-slate-300 text-[#2280FF] focus:ring-[#2280FF]"
+            />
+            <label htmlFor={consentFieldId} className="text-sm leading-relaxed text-slate-600">
+              {t.consentLabel}
+            </label>
+          </div>
+
+          <p className="text-xs text-slate-500">{t.consentNote}</p>
+
+          <div
+            aria-live="assertive"
+            id="error-message"
+            className="hidden rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+          />
+          <div
+            aria-live="polite"
+            id="success-message"
+            className="hidden rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700"
+          />
+
+          <input type="text" name="email_address_check" className="input--hidden" defaultValue="" tabIndex={-1} autoComplete="off" />
+          <input type="hidden" name="LANGUAGE" value={lang} />
+          <input type="hidden" name="locale" value={localeValue} />
+          {sourceUrl && <input type="hidden" name="SOURCE_URL" value={sourceUrl} />}
+
+          <div className="g-recaptcha-v3" data-sitekey={RECAPTCHA_SITE_KEY} />
+
+          <button type="submit" className="btn-primary w-full justify-center px-8 py-4 text-base font-semibold">
+            {t.submit}
+          </button>
+        </form>
       </div>
-
-      <form
-        method="POST"
-        action={POST_URL}
-        className="space-y-6"
-        noValidate
-      >
-        <div className="space-y-2">
-          <label htmlFor="newsletter-email" className="block text-sm font-semibold text-[#121C2D]">
-            {t.emailLabel}
-          </label>
-          <input
-            id="newsletter-email"
-            name="EMAIL"
-            type="email"
-            required
-            placeholder={t.emailPlaceholder}
-            className="w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-base focus:border-[#2280FF] focus:ring-2 focus:ring-[#2280FF]/30 transition"
-          />
-        </div>
-
-        <div className="flex items-start gap-3">
-          <input
-            id="newsletter-consent"
-            name="OPT_IN"
-            type="checkbox"
-            required
-            className="mt-1 h-5 w-5 rounded border-slate-300 text-[#2280FF] focus:ring-[#2280FF]"
-          />
-          <label htmlFor="newsletter-consent" className="text-sm text-slate-600 leading-relaxed">
-            {t.consentLabel}
-          </label>
-        </div>
-
-        <p className="text-xs text-slate-500">{t.consentNote}</p>
-
-        <div aria-live="assertive" id="error-message" className="hidden rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" />
-        <div aria-live="polite" id="success-message" className="hidden rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700" />
-
-        <input type="text" name="email_address_check" className="input--hidden" defaultValue="" tabIndex={-1} autoComplete="off" />
-        <input type="hidden" name="LANGUAGE" value={lang} />
-        <input type="hidden" name="locale" value={localeValue} />
-        {sourceUrl && <input type="hidden" name="SOURCE_URL" value={sourceUrl} />}
-
-        <button
-          type="submit"
-          className="w-full md:w-auto inline-flex items-center justify-center rounded-full bg-[#2280FF] px-8 py-3 text-base font-semibold text-white shadow-lg shadow-[#2280FF]/30 hover:bg-[#1a64c7] transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#2280FF]"
-        >
-          {t.submit}
-        </button>
-      </form>
-    </div>
+    </section>
   );
 };
 

--- a/src/components/SignupForm.tsx
+++ b/src/components/SignupForm.tsx
@@ -6,36 +6,58 @@ const RECAPTCHA_SITE_KEY = '6Lf0RtYrAAAAAMnsVvJx3DTeKDVGi2ZQElXygdM-';
 
 const copy = {
   fr: {
-    heading: 'Infolettre PME Québec',
-    subheading: 'Automatisation et IA pour dirigeants pressés',
+    heading: 'Infolettre PME Québec — The Automated SMB',
+    subheading: "Votre rendez-vous hebdo avec l’automatisation et l’IA",
     body:
-      'Deux fois par mois, recevez des tactiques applicables pour gagner du temps, éviter des erreurs coûteuses et rester conforme à la Loi 25 — sans blabla.',
+      'Chaque semaine, recevez des conseils concrets pour gagner du temps, réduire vos coûts et rester conforme à la Loi 25. Des tactiques simples, pensées pour les PME québécoises — applicables dès maintenant.',
     emailLabel: 'Adresse courriel professionnelle',
     emailPlaceholder: 'prenom.nom@entreprise.com',
     consentLabel:
-      "Je consens à recevoir les communications de The Automated SMB et comprends que je pourrai me désabonner en tout temps.",
-    consentNote: 'Vos données sont traitées au Québec et conformes à la Loi 25 et à la LCAP.',
-    submit: "Recevoir l'infolettre",
+      'Je consens à recevoir les communications de The Automated SMB et je comprends que je peux me désabonner en tout temps.',
+    submit: 'Recevoir l’infolettre chaque semaine',
     successTitle: 'Merci! Votre inscription est confirmée.',
     successBody: 'Vérifiez votre boîte de réception pour le courriel de bienvenue.',
     errorTitle: "Oups! Une erreur est survenue.",
-    errorBody: 'Veuillez réessayer ou nous écrire à hello@simonparis.ca.'
+    errorBody: 'Veuillez réessayer ou nous écrire à hello@simonparis.ca.',
+    trustLine: (
+      <>
+        Vos données sont protégées. Consultez notre{' '}
+        <a
+          href="/privacy"
+          className="font-semibold text-[#2280FF] hover:text-[#139E9B] transition-colors"
+        >
+          Politique de confidentialité
+        </a>
+        .
+      </>
+    )
   },
   en: {
-    heading: 'Québec SMB AI Newsletter',
-    subheading: 'Automation guidance for owners who move fast',
+    heading: 'Québec SMB AI Newsletter — The Automated SMB',
+    subheading: 'Your weekly briefing on automation and AI',
     body:
-      'Every two weeks, receive concise playbooks that save hours, prevent costly mistakes, and keep your team compliant with Law 25 — no fluff.',
+      'Every week, get clear, actionable insights to save time, cut costs, and stay compliant with Law 25. No jargon — just practical tactics designed for Québec SMBs.',
     emailLabel: 'Business email address',
     emailPlaceholder: 'firstname.lastname@company.com',
     consentLabel:
       'I consent to receive communications from The Automated SMB and understand I can unsubscribe at any time.',
-    consentNote: "Your data is handled in Québec and compliant with Law 25 and Canada's Anti-Spam Legislation.",
-    submit: 'Join the newsletter',
+    submit: 'Get the weekly newsletter',
     successTitle: "Thanks! You're on the list.",
     successBody: 'Look for the welcome email in your inbox within a few minutes.',
     errorTitle: 'Oops! Something went wrong.',
-    errorBody: 'Please try again or email hello@simonparis.ca.'
+    errorBody: 'Please try again or email hello@simonparis.ca.',
+    trustLine: (
+      <>
+        Your data is protected. See our{' '}
+        <a
+          href="/privacy"
+          className="font-semibold text-[#2280FF] hover:text-[#139E9B] transition-colors"
+        >
+          Privacy Policy
+        </a>
+        .
+      </>
+    )
   }
 } as const;
 
@@ -121,19 +143,17 @@ export const SignupForm: React.FC<SignupFormProps> = ({ lang }) => {
   const localeValue = useMemo(() => lang, [lang]);
 
   return (
-    <section className="relative">
-      <div className="absolute inset-0 -z-10 rounded-[32px] bg-gradient-to-br from-slate-100 via-white to-slate-100" />
-      <div className="relative mx-auto max-w-[600px] rounded-[32px] border border-slate-200 bg-white/90 p-10 shadow-[0_25px_55px_rgba(18,28,45,0.12)] backdrop-blur">
-        <header className="mb-10 space-y-4 text-center md:text-left">
-          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-500">The Automated SMB</p>
-          <h1 className="text-3xl font-semibold text-slate-900 md:text-4xl">{t.heading}</h1>
-          <p className="text-lg font-medium text-slate-600">{t.subheading}</p>
-          <p className="text-base leading-relaxed text-slate-600">{t.body}</p>
+    <section className="w-full">
+      <div className="mx-auto max-w-[600px] rounded-[12px] border border-[#E5E7EB] bg-white p-8 shadow-[0_18px_40px_rgba(18,28,45,0.08)] sm:p-10">
+        <header className="mb-10 space-y-4">
+          <h1 className="text-3xl font-semibold text-[#121C2D] md:text-4xl">{t.heading}</h1>
+          <p className="text-lg font-semibold text-[#1F2937] md:text-xl">{t.subheading}</p>
+          <p className="text-base leading-relaxed text-[#4B5563]">{t.body}</p>
         </header>
 
         <form method="POST" action={POST_URL} className="space-y-6" noValidate>
           <div className="space-y-2">
-            <label htmlFor={emailFieldId} className="text-sm font-semibold text-slate-700">
+            <label htmlFor={emailFieldId} className="text-sm font-semibold text-[#1F2937]">
               {t.emailLabel}
             </label>
             <input
@@ -142,47 +162,53 @@ export const SignupForm: React.FC<SignupFormProps> = ({ lang }) => {
               type="email"
               required
               placeholder={t.emailPlaceholder}
-              className="w-full rounded-2xl border border-slate-300 bg-white px-5 py-4 text-base text-slate-900 shadow-sm transition focus:border-[#2280FF] focus:outline-none focus:ring-4 focus:ring-[#2280FF]/20"
+              className="w-full rounded-xl border border-[#D1D5DB] bg-white px-5 py-4 text-base text-[#111827] shadow-sm transition focus:border-[#2280FF] focus:outline-none focus:ring-4 focus:ring-[#2280FF]/20"
             />
           </div>
 
-          <div className="flex items-start gap-3 rounded-2xl bg-slate-50/80 p-4">
+          <div className="flex items-start gap-3 rounded-xl bg-[#F3F4F6] p-4">
             <input
               id={consentFieldId}
               name="OPT_IN"
               type="checkbox"
               required
-              className="mt-1 h-5 w-5 rounded border-slate-300 text-[#2280FF] focus:ring-[#2280FF]"
+              className="mt-1 h-5 w-5 rounded border-[#D1D5DB] text-[#2280FF] focus:ring-[#2280FF]"
             />
-            <label htmlFor={consentFieldId} className="text-sm leading-relaxed text-slate-600">
+            <label htmlFor={consentFieldId} className="text-sm leading-relaxed text-[#4B5563]">
               {t.consentLabel}
             </label>
           </div>
 
-          <p className="text-xs text-slate-500">{t.consentNote}</p>
-
           <div
             aria-live="assertive"
             id="error-message"
-            className="hidden rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
-          />
+            className="hidden rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+          >
+            <p className="font-semibold">{t.errorTitle}</p>
+            <p className="mt-1 leading-relaxed">{t.errorBody}</p>
+          </div>
           <div
             aria-live="polite"
             id="success-message"
-            className="hidden rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700"
-          />
+            className="hidden rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700"
+          >
+            <p className="font-semibold">{t.successTitle}</p>
+            <p className="mt-1 leading-relaxed">{t.successBody}</p>
+          </div>
 
           <input type="text" name="email_address_check" className="input--hidden" defaultValue="" tabIndex={-1} autoComplete="off" />
           <input type="hidden" name="LANGUAGE" value={lang} />
           <input type="hidden" name="locale" value={localeValue} />
           {sourceUrl && <input type="hidden" name="SOURCE_URL" value={sourceUrl} />}
 
-          <div className="g-recaptcha-v3" data-sitekey={RECAPTCHA_SITE_KEY} />
+          <div className="g-recaptcha-v3" data-sitekey={RECAPTCHA_SITE_KEY} style={{ display: 'none' }} />
 
-          <button type="submit" className="btn-primary w-full justify-center px-8 py-4 text-base font-semibold">
+          <button type="submit" className="btn-primary w-full normal-case px-8 py-4 text-base font-semibold">
             {t.submit}
           </button>
         </form>
+
+        <p className="mt-6 text-sm text-[#6B7280]">{t.trustLine}</p>
       </div>
     </section>
   );

--- a/src/components/SignupForm.tsx
+++ b/src/components/SignupForm.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { Lock } from 'lucide-react';
 import { translations, type Language } from '../i18n';
 
 const POST_URL =
@@ -21,8 +22,15 @@ interface SignupFormProps {
 }
 
 export const SignupForm: React.FC<SignupFormProps> = ({ lang }) => {
-  const signupCopy = translations[lang].newsletter.signup;
+  const copy = translations[lang].newsletter;
   const [sourceUrl, setSourceUrl] = useState('');
+
+  const trustContent = useMemo(() => {
+    const privacyLabel = lang === 'fr' ? 'Politique de confidentialité' : 'Privacy Policy';
+    const sanitized = copy.trust.replace(/^🔒\s*/, '');
+    const [before, after = ''] = sanitized.split(privacyLabel);
+    return { before, after, privacyLabel };
+  }, [copy.trust, lang]);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -57,11 +65,11 @@ export const SignupForm: React.FC<SignupFormProps> = ({ lang }) => {
   return (
     <>
       <section className="w-full font-inter">
-        <div className="mx-auto w-full max-w-[600px] rounded-[12px] bg-white/95 p-8 shadow-[0_32px_80px_rgba(18,28,45,0.12)] ring-1 ring-black/5 sm:p-12">
-          <header className="mb-10 space-y-5 md:space-y-6">
-            <h1 className="text-3xl font-semibold text-[#121C2D] md:text-4xl">{signupCopy.heading}</h1>
-            <p className="text-lg font-semibold text-[#139E9C] md:text-xl">{signupCopy.subheading}</p>
-            <p className="text-base leading-relaxed text-[#4B5563]">{signupCopy.body}</p>
+        <div className="mx-auto w-full max-w-[540px] rounded-[12px] bg-white/95 p-8 shadow-[0_32px_80px_rgba(18,28,45,0.12)] ring-1 ring-black/5 sm:p-12">
+          <header className="mb-12 space-y-4 md:space-y-5">
+            <h1 className="text-3xl font-semibold text-[#121C2D] md:text-4xl">{copy.title}</h1>
+            <p className="text-lg font-semibold text-[#139E9C] md:text-xl">{copy.subtitle}</p>
+            <p className="text-base leading-relaxed text-[#4B5563] whitespace-pre-line">{copy.body}</p>
           </header>
 
           <form
@@ -69,20 +77,20 @@ export const SignupForm: React.FC<SignupFormProps> = ({ lang }) => {
             data-type="subscription"
             method="POST"
             action={POST_URL}
-            className="space-y-6"
+            className="space-y-8"
           >
             <div className="space-y-2">
               <label htmlFor="EMAIL" className="text-sm font-semibold text-[#1F2937]">
-                {signupCopy.emailLabel}
+                {copy.emailLabel}
               </label>
               <input
                 id="EMAIL"
                 name="EMAIL"
                 type="email"
                 required
-                placeholder={signupCopy.emailPlaceholder}
+                placeholder={copy.emailPlaceholder}
                 autoComplete="email"
-                className="w-full rounded-[10px] border border-[#D1D5DB] bg-white px-5 py-3 text-base text-[#121C2D] shadow-sm transition focus:border-[#139E9C] focus:outline-none focus:ring-4 focus:ring-[#139E9C]/20"
+                className="w-full rounded-[12px] border border-[#D1D5DB] bg-white px-5 py-3 text-base text-[#121C2D] shadow-sm transition focus:border-[#139E9C] focus:outline-none focus:ring-4 focus:ring-[#139E9C]/20"
               />
             </div>
 
@@ -96,7 +104,7 @@ export const SignupForm: React.FC<SignupFormProps> = ({ lang }) => {
                 className="mt-1 h-5 w-5 rounded border-[#D1D5DB] text-[#139E9C] focus:ring-[#139E9C]"
               />
               <label htmlFor="OPT_IN" className="text-sm leading-relaxed text-[#4B5563]">
-                {signupCopy.consentLabel}
+                {copy.consent}
               </label>
             </div>
 
@@ -106,8 +114,8 @@ export const SignupForm: React.FC<SignupFormProps> = ({ lang }) => {
               style={{ display: 'none' }}
               className="rounded-[8px] border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
             >
-              <p className="font-semibold">{signupCopy.errorTitle}</p>
-              <p className="mt-1 leading-relaxed">{signupCopy.errorBody}</p>
+              <p className="font-semibold">{copy.error.title}</p>
+              <p className="mt-1 leading-relaxed">{copy.error.body}</p>
             </div>
 
             <div
@@ -116,11 +124,11 @@ export const SignupForm: React.FC<SignupFormProps> = ({ lang }) => {
               style={{ display: 'none' }}
               className="rounded-[8px] border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700"
             >
-              <p className="font-semibold">{signupCopy.successTitle}</p>
-              <p className="mt-1 leading-relaxed">{signupCopy.successBody}</p>
+              <p className="font-semibold">{copy.success.title}</p>
+              <p className="mt-1 leading-relaxed">{copy.success.body}</p>
             </div>
 
-            <input type="text" name="email_address_check" value="" className="hidden" />
+            <input type="text" name="email_address_check" value="" className="input--hidden" />
             <input type="hidden" name="LANGUAGE" value={lang} />
             <input type="hidden" name="locale" value={lang} />
             <input type="hidden" name="SOURCE_URL" value={sourceUrl} />
@@ -128,20 +136,23 @@ export const SignupForm: React.FC<SignupFormProps> = ({ lang }) => {
             <div className="g-recaptcha-v3" data-sitekey={RECAPTCHA_SITE_KEY} style={{ display: 'none' }} />
 
             <button type="submit" className="btn-primary w-full">
-              {signupCopy.submit}
+              {copy.submit}
             </button>
           </form>
 
-          <p className="mt-8 text-sm text-[#6B7280]">
-            {signupCopy.trustLine.prefix}
-            <a
-              href={lang === 'fr' ? '/fr/politique-confidentialite' : '/privacy'}
-              className="font-semibold text-[#139E9C] transition-colors hover:text-[#0F807E]"
-            >
-              {signupCopy.trustLine.linkLabel}
-            </a>
-            {signupCopy.trustLine.suffix}
-          </p>
+          <div className="mt-10 flex items-start gap-3 text-sm text-[#4B5563]">
+            <Lock className="mt-0.5 h-4 w-4 text-[#139E9C]" aria-hidden="true" />
+            <p>
+              {trustContent.before}
+              <a
+                href={lang === 'fr' ? '/fr/politique-confidentialite' : '/privacy'}
+                className="font-semibold text-[#139E9C] transition-colors hover:text-[#0F807E]"
+              >
+                {trustContent.privacyLabel}
+              </a>
+              {trustContent.after}
+            </p>
+          </div>
         </div>
       </section>
 

--- a/src/components/SignupForm.tsx
+++ b/src/components/SignupForm.tsx
@@ -6,12 +6,12 @@ const RECAPTCHA_SITE_KEY = '6Lf0RtYrAAAAAMnsVvJx3DTeKDVGi2ZQElXygdM-';
 
 const copy = {
   fr: {
-    heading: 'Infolettre PME Québec — The Automated SMB',
-    subheading: "Votre rendez-vous hebdo avec l’automatisation et l’IA",
+    heading: 'The Automated SMB',
+    subheading: 'L’infolettre hebdo pragmatique pour moderniser votre PME',
     body:
-      'Chaque semaine, recevez des conseils concrets pour gagner du temps, réduire vos coûts et rester conforme à la Loi 25. Des tactiques simples, pensées pour les PME québécoises — applicables dès maintenant.',
-    emailLabel: 'Adresse courriel professionnelle',
-    emailPlaceholder: 'prenom.nom@entreprise.com',
+      'Chaque semaine, recevez des tactiques concrètes pour gagner du temps, réduire vos coûts et rester conforme à la Loi 25. Des conseils clairs, applicables dès maintenant.',
+    emailLabel: 'Adresse courriel',
+    emailPlaceholder: 'prenom@entreprise.com',
     consentLabel:
       'Je consens à recevoir les communications de The Automated SMB et je comprends que je peux me désabonner en tout temps.',
     submit: 'Recevoir l’infolettre chaque semaine',
@@ -24,7 +24,7 @@ const copy = {
         Vos données sont protégées. Consultez notre{' '}
         <a
           href="/privacy"
-          className="font-semibold text-[#2280FF] hover:text-[#139E9B] transition-colors"
+          className="font-semibold text-[#139E9B] transition-colors hover:text-[#2280FF]"
         >
           Politique de confidentialité
         </a>
@@ -33,12 +33,12 @@ const copy = {
     )
   },
   en: {
-    heading: 'Québec SMB AI Newsletter — The Automated SMB',
-    subheading: 'Your weekly briefing on automation and AI',
+    heading: 'The Automated SMB',
+    subheading: 'Your weekly playbook to modernize your SMB',
     body:
-      'Every week, get clear, actionable insights to save time, cut costs, and stay compliant with Law 25. No jargon — just practical tactics designed for Québec SMBs.',
-    emailLabel: 'Business email address',
-    emailPlaceholder: 'firstname.lastname@company.com',
+      'Every week, get actionable tactics to save time, cut costs, and stay compliant with Law 25. Clear insights, ready to use immediately.',
+    emailLabel: 'Email address',
+    emailPlaceholder: 'you@company.com',
     consentLabel:
       'I consent to receive communications from The Automated SMB and understand I can unsubscribe at any time.',
     submit: 'Get the weekly newsletter',
@@ -51,7 +51,7 @@ const copy = {
         Your data is protected. See our{' '}
         <a
           href="/privacy"
-          className="font-semibold text-[#2280FF] hover:text-[#139E9B] transition-colors"
+          className="font-semibold text-[#139E9B] transition-colors hover:text-[#2280FF]"
         >
           Privacy Policy
         </a>
@@ -144,10 +144,10 @@ export const SignupForm: React.FC<SignupFormProps> = ({ lang }) => {
 
   return (
     <section className="w-full">
-      <div className="mx-auto max-w-[600px] rounded-[12px] border border-[#E5E7EB] bg-white p-8 shadow-[0_18px_40px_rgba(18,28,45,0.08)] sm:p-10">
-        <header className="mb-10 space-y-4">
+      <div className="mx-auto w-full max-w-[600px] rounded-[10px] bg-white p-8 shadow-[0_32px_80px_rgba(18,28,45,0.12)] ring-1 ring-black/5 sm:p-12">
+        <header className="mb-8 space-y-4">
           <h1 className="text-3xl font-semibold text-[#121C2D] md:text-4xl">{t.heading}</h1>
-          <p className="text-lg font-semibold text-[#1F2937] md:text-xl">{t.subheading}</p>
+          <p className="text-lg font-medium text-[#1F2937] md:text-xl">{t.subheading}</p>
           <p className="text-base leading-relaxed text-[#4B5563]">{t.body}</p>
         </header>
 
@@ -162,17 +162,17 @@ export const SignupForm: React.FC<SignupFormProps> = ({ lang }) => {
               type="email"
               required
               placeholder={t.emailPlaceholder}
-              className="w-full rounded-xl border border-[#D1D5DB] bg-white px-5 py-4 text-base text-[#111827] shadow-sm transition focus:border-[#2280FF] focus:outline-none focus:ring-4 focus:ring-[#2280FF]/20"
+              className="w-full rounded-[10px] border border-[#D1D5DB] bg-white px-5 py-3 text-base text-[#121C2D] shadow-sm transition focus:border-[#139E9B] focus:outline-none focus:ring-4 focus:ring-[#139E9B]/20"
             />
           </div>
 
-          <div className="flex items-start gap-3 rounded-xl bg-[#F3F4F6] p-4">
+          <div className="flex items-start gap-3">
             <input
               id={consentFieldId}
               name="OPT_IN"
               type="checkbox"
               required
-              className="mt-1 h-5 w-5 rounded border-[#D1D5DB] text-[#2280FF] focus:ring-[#2280FF]"
+              className="mt-1 h-5 w-5 rounded border-[#D1D5DB] text-[#139E9B] focus:ring-[#139E9B]"
             />
             <label htmlFor={consentFieldId} className="text-sm leading-relaxed text-[#4B5563]">
               {t.consentLabel}
@@ -182,7 +182,7 @@ export const SignupForm: React.FC<SignupFormProps> = ({ lang }) => {
           <div
             aria-live="assertive"
             id="error-message"
-            className="hidden rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+            className="hidden rounded-[8px] border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
           >
             <p className="font-semibold">{t.errorTitle}</p>
             <p className="mt-1 leading-relaxed">{t.errorBody}</p>
@@ -190,7 +190,7 @@ export const SignupForm: React.FC<SignupFormProps> = ({ lang }) => {
           <div
             aria-live="polite"
             id="success-message"
-            className="hidden rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700"
+            className="hidden rounded-[8px] border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700"
           >
             <p className="font-semibold">{t.successTitle}</p>
             <p className="mt-1 leading-relaxed">{t.successBody}</p>
@@ -203,12 +203,16 @@ export const SignupForm: React.FC<SignupFormProps> = ({ lang }) => {
 
           <div className="g-recaptcha-v3" data-sitekey={RECAPTCHA_SITE_KEY} style={{ display: 'none' }} />
 
-          <button type="submit" className="btn-primary w-full normal-case px-8 py-4 text-base font-semibold">
+          <button
+            type="submit"
+            className="btn-primary w-full text-base font-semibold"
+            style={{ textTransform: 'none' }}
+          >
             {t.submit}
           </button>
         </form>
 
-        <p className="mt-6 text-sm text-[#6B7280]">{t.trustLine}</p>
+        <p className="mt-8 text-sm text-[#6B7280]">{t.trustLine}</p>
       </div>
     </section>
   );

--- a/src/components/SignupForm.tsx
+++ b/src/components/SignupForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Lock } from 'lucide-react';
 import { translations, type Language } from '../i18n';
 
@@ -24,13 +24,12 @@ interface SignupFormProps {
 export const SignupForm: React.FC<SignupFormProps> = ({ lang }) => {
   const copy = translations[lang].newsletter;
   const [sourceUrl, setSourceUrl] = useState('');
-
-  const trustContent = useMemo(() => {
-    const privacyLabel = lang === 'fr' ? 'Politique de confidentialité' : 'Privacy Policy';
-    const sanitized = copy.trust.replace(/^🔒\s*/, '');
-    const [before, after = ''] = sanitized.split(privacyLabel);
-    return { before, after, privacyLabel };
-  }, [copy.trust, lang]);
+  const bodyLines = copy.bodyLines ?? [];
+  const trustCopy = copy.trust ?? {
+    prefix: '',
+    linkLabel: '',
+    suffix: ''
+  };
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -69,7 +68,13 @@ export const SignupForm: React.FC<SignupFormProps> = ({ lang }) => {
           <header className="mb-12 space-y-4 md:space-y-5">
             <h1 className="text-3xl font-semibold text-[#121C2D] md:text-4xl">{copy.title}</h1>
             <p className="text-lg font-semibold text-[#139E9C] md:text-xl">{copy.subtitle}</p>
-            <p className="text-base leading-relaxed text-[#4B5563] whitespace-pre-line">{copy.body}</p>
+            <div className="space-y-2">
+              {bodyLines.map(line => (
+                <p key={line} className="text-base leading-relaxed text-[#4B5563]">
+                  {line}
+                </p>
+              ))}
+            </div>
           </header>
 
           <form
@@ -77,7 +82,7 @@ export const SignupForm: React.FC<SignupFormProps> = ({ lang }) => {
             data-type="subscription"
             method="POST"
             action={POST_URL}
-            className="space-y-8"
+            className="space-y-9"
           >
             <div className="space-y-2">
               <label htmlFor="EMAIL" className="text-sm font-semibold text-[#1F2937]">
@@ -143,14 +148,14 @@ export const SignupForm: React.FC<SignupFormProps> = ({ lang }) => {
           <div className="mt-10 flex items-start gap-3 text-sm text-[#4B5563]">
             <Lock className="mt-0.5 h-4 w-4 text-[#139E9C]" aria-hidden="true" />
             <p>
-              {trustContent.before}
+              {trustCopy.prefix}
               <a
                 href={lang === 'fr' ? '/fr/politique-confidentialite' : '/privacy'}
                 className="font-semibold text-[#139E9C] transition-colors hover:text-[#0F807E]"
               >
-                {trustContent.privacyLabel}
+                {trustCopy.linkLabel}
               </a>
-              {trustContent.after}
+              {trustCopy.suffix}
             </p>
           </div>
         </div>

--- a/src/components/SignupForm.tsx
+++ b/src/components/SignupForm.tsx
@@ -144,8 +144,8 @@ export const SignupForm: React.FC<SignupFormProps> = ({ lang }) => {
 
   return (
     <section className="w-full">
-      <div className="mx-auto w-full max-w-[600px] rounded-[10px] bg-white p-8 shadow-[0_32px_80px_rgba(18,28,45,0.12)] ring-1 ring-black/5 sm:p-12">
-        <header className="mb-8 space-y-4">
+      <div className="mx-auto w-full max-w-[600px] rounded-[12px] bg-white p-8 shadow-[0_32px_80px_rgba(18,28,45,0.12)] ring-1 ring-black/5 sm:p-12">
+        <header className="mb-10 space-y-5 md:space-y-6">
           <h1 className="text-3xl font-semibold text-[#121C2D] md:text-4xl">{t.heading}</h1>
           <p className="text-lg font-medium text-[#1F2937] md:text-xl">{t.subheading}</p>
           <p className="text-base leading-relaxed text-[#4B5563]">{t.body}</p>
@@ -162,7 +162,7 @@ export const SignupForm: React.FC<SignupFormProps> = ({ lang }) => {
               type="email"
               required
               placeholder={t.emailPlaceholder}
-              className="w-full rounded-[10px] border border-[#D1D5DB] bg-white px-5 py-3 text-base text-[#121C2D] shadow-sm transition focus:border-[#139E9B] focus:outline-none focus:ring-4 focus:ring-[#139E9B]/20"
+              className="w-full rounded-[10px] border border-[#D1D5DB] bg-white px-5 py-3 text-base font-inter text-[#121C2D] shadow-sm transition focus:border-[#139E9B] focus:outline-none focus:ring-4 focus:ring-[#139E9B]/20"
             />
           </div>
 
@@ -205,8 +205,7 @@ export const SignupForm: React.FC<SignupFormProps> = ({ lang }) => {
 
           <button
             type="submit"
-            className="btn-primary w-full text-base font-semibold"
-            style={{ textTransform: 'none' }}
+            className="btn-primary w-full"
           >
             {t.submit}
           </button>

--- a/src/components/SignupForm.tsx
+++ b/src/components/SignupForm.tsx
@@ -1,0 +1,191 @@
+import React, { useEffect, useMemo, useState } from 'react';
+
+const POST_URL =
+  'https://c454d84b.sibforms.com/serve/MUIFAH7NOSykJlqeKP4c-jXRt7b-0MCgSB0R8BROAkZEQAbRZUO09B2nZUBGX-BfJqMMUURc1KBYeqGz7QduVv9MMy4fEEABw-5k98uGvJ18IAljU5oid79WFyl5-fBS2v5Ng8XlZEx7u7IZ9Dp6gCdZaTRY9trZH1U_GfpFHWxUpo0yvGpQR3DlmKDky65MJJvyhZoT0t1GbEkE';
+const RECAPTCHA_SITE_KEY = '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI';
+
+const copy = {
+  fr: {
+    heading: 'Infolettre PME Québec',
+    intro:
+      'Recevez des tactiques concrètes d\'automatisation et d\'IA pour les PME québécoises. Un courriel 2x par mois, sans spam.',
+    emailLabel: 'Adresse courriel',
+    emailPlaceholder: 'nom@entreprise.com',
+    consentLabel:
+      "J'accepte de recevoir des communications de The Automated SMB et je peux me désabonner en tout temps.",
+    submit: "Je m'inscris",
+    consentNote: 'Nous respectons la Loi 25 et la Loi anti-pourriel (LCAP).',
+    successTitle: 'Merci! Votre inscription est confirmée.',
+    successBody: 'Vérifiez vos courriels pour le message de bienvenue.',
+    errorTitle: "Oups! Une erreur est survenue.",
+    errorBody: 'Veuillez réessayer ou nous écrire à hello@simonparis.ca.',
+    toggleLabel: 'Version anglaise',
+    toggleHref: '/en/newsletter'
+  },
+  en: {
+    heading: 'Québec SMB AI Newsletter',
+    intro:
+      'Get bilingual automation playbooks for Québec SMEs. Twice-monthly insights—actionable, no fluff.',
+    emailLabel: 'Email address',
+    emailPlaceholder: 'name@company.com',
+    consentLabel:
+      'I agree to receive communications from The Automated SMB and understand I can unsubscribe anytime.',
+    submit: 'Subscribe now',
+    consentNote: 'Fully compliant with Law 25 and Canada\'s Anti-Spam Legislation.',
+    successTitle: 'Thanks! You are on the list.',
+    successBody: 'Check your inbox for the welcome email.',
+    errorTitle: 'Oops! Something went wrong.',
+    errorBody: 'Please try again or email hello@simonparis.ca.',
+    toggleLabel: 'Version française',
+    toggleHref: '/fr/newsletter'
+  }
+} as const;
+
+export type SignupFormLang = keyof typeof copy;
+
+interface SignupFormProps {
+  lang: SignupFormLang;
+}
+
+const ensureHeadLink = (selector: string, create: () => HTMLLinkElement) => {
+  let link = document.head.querySelector<HTMLLinkElement>(selector);
+  if (!link) {
+    link = create();
+    document.head.appendChild(link);
+  }
+  return link;
+};
+
+const ensureHeadScript = (selector: string, create: () => HTMLScriptElement) => {
+  let script = document.head.querySelector<HTMLScriptElement>(selector);
+  if (!script) {
+    script = create();
+    document.head.appendChild(script);
+  }
+  return script;
+};
+
+export const SignupForm: React.FC<SignupFormProps> = ({ lang }) => {
+  const t = copy[lang];
+  const [sourceUrl, setSourceUrl] = useState('');
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    setSourceUrl(window.location.href);
+  }, []);
+
+  const localeValue = useMemo(() => lang, [lang]);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    ensureHeadLink("link[data-brevo='styles']", () => {
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = 'https://sibforms.com/forms/end-form/build/sib-styles.css';
+      link.dataset.brevo = 'styles';
+      return link;
+    });
+
+    ensureHeadScript("script[data-brevo='main']", () => {
+      const script = document.createElement('script');
+      script.src = 'https://sibforms.com/forms/end-form/build/main.js';
+      script.defer = true;
+      script.dataset.brevo = 'main';
+      return script;
+    });
+  }, []);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const selector = "script[data-recaptcha='loader']";
+    const existing = document.head.querySelector<HTMLScriptElement>(selector);
+    const scriptSrc = `https://www.google.com/recaptcha/api.js?render=${RECAPTCHA_SITE_KEY}&hl=${lang}`;
+
+    if (existing) {
+      if (existing.src !== scriptSrc) {
+        existing.remove();
+      } else {
+        return;
+      }
+    }
+
+    ensureHeadScript(selector, () => {
+      const script = document.createElement('script');
+      script.src = scriptSrc;
+      script.defer = true;
+      script.dataset.recaptcha = 'loader';
+      return script;
+    });
+  }, [lang]);
+
+  return (
+    <div className="bg-white shadow-xl rounded-3xl p-8 md:p-12 border border-slate-200">
+      <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-6 mb-10">
+        <div className="space-y-3 text-center md:text-left">
+          <p className="text-sm uppercase tracking-widest text-[#2280FF]/80 font-semibold">The Automated SMB</p>
+          <h1 className="text-3xl md:text-4xl font-bold text-[#121C2D]">{t.heading}</h1>
+          <p className="text-base md:text-lg text-slate-600 leading-relaxed">{t.intro}</p>
+        </div>
+        <a
+          href={t.toggleHref}
+          className="self-center md:self-start inline-flex items-center px-4 py-2 rounded-full border border-[#2280FF] text-[#2280FF] font-medium hover:bg-[#2280FF]/10 transition"
+        >
+          {t.toggleLabel}
+        </a>
+      </div>
+
+      <form
+        method="POST"
+        action={POST_URL}
+        className="space-y-6"
+        noValidate
+      >
+        <div className="space-y-2">
+          <label htmlFor="newsletter-email" className="block text-sm font-semibold text-[#121C2D]">
+            {t.emailLabel}
+          </label>
+          <input
+            id="newsletter-email"
+            name="EMAIL"
+            type="email"
+            required
+            placeholder={t.emailPlaceholder}
+            className="w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-base focus:border-[#2280FF] focus:ring-2 focus:ring-[#2280FF]/30 transition"
+          />
+        </div>
+
+        <div className="flex items-start gap-3">
+          <input
+            id="newsletter-consent"
+            name="OPT_IN"
+            type="checkbox"
+            required
+            className="mt-1 h-5 w-5 rounded border-slate-300 text-[#2280FF] focus:ring-[#2280FF]"
+          />
+          <label htmlFor="newsletter-consent" className="text-sm text-slate-600 leading-relaxed">
+            {t.consentLabel}
+          </label>
+        </div>
+
+        <p className="text-xs text-slate-500">{t.consentNote}</p>
+
+        <div aria-live="assertive" id="error-message" className="hidden rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" />
+        <div aria-live="polite" id="success-message" className="hidden rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700" />
+
+        <input type="text" name="email_address_check" className="input--hidden" defaultValue="" tabIndex={-1} autoComplete="off" />
+        <input type="hidden" name="LANGUAGE" value={lang} />
+        <input type="hidden" name="locale" value={localeValue} />
+        {sourceUrl && <input type="hidden" name="SOURCE_URL" value={sourceUrl} />}
+
+        <button
+          type="submit"
+          className="w-full md:w-auto inline-flex items-center justify-center rounded-full bg-[#2280FF] px-8 py-3 text-base font-semibold text-white shadow-lg shadow-[#2280FF]/30 hover:bg-[#1a64c7] transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#2280FF]"
+        >
+          {t.submit}
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default SignupForm;

--- a/src/components/SignupForm.tsx
+++ b/src/components/SignupForm.tsx
@@ -1,71 +1,9 @@
-import React, { useEffect, useMemo, useState, useId } from 'react';
+import React, { useEffect, useState } from 'react';
+import { translations, type Language } from '../i18n';
 
 const POST_URL =
   'https://c454d84b.sibforms.com/serve/MUIFAH7NOSykJlqeKP4c-jXRt7b-0MCgSB0R8BROAkZEQAbRZUO09B2nZUBGX-BfJqMMUURc1KBYeqGz7QduVv9MMy4fEEABw-5k98uGvJ18IAljU5oid79WFyl5-fBS2v5Ng8XlZEx7u7IZ9Dp6gCdZaTRY9trZH1U_GfpFHWxUpo0yvGpQR3DlmKDky65MJJvyhZoT0t1GbEkE';
 const RECAPTCHA_SITE_KEY = '6Lf0RtYrAAAAAMnsVvJx3DTeKDVGi2ZQElXygdM-';
-
-const copy = {
-  fr: {
-    heading: 'The Automated SMB',
-    subheading: 'L’infolettre hebdo pragmatique pour moderniser votre PME',
-    body:
-      'Chaque semaine, recevez des tactiques concrètes pour gagner du temps, réduire vos coûts et rester conforme à la Loi 25. Des conseils clairs, applicables dès maintenant.',
-    emailLabel: 'Adresse courriel',
-    emailPlaceholder: 'prenom@entreprise.com',
-    consentLabel:
-      'Je consens à recevoir les communications de The Automated SMB et je comprends que je peux me désabonner en tout temps.',
-    submit: 'Recevoir l’infolettre chaque semaine',
-    successTitle: 'Merci! Votre inscription est confirmée.',
-    successBody: 'Vérifiez votre boîte de réception pour le courriel de bienvenue.',
-    errorTitle: "Oups! Une erreur est survenue.",
-    errorBody: 'Veuillez réessayer ou nous écrire à hello@simonparis.ca.',
-    trustLine: (
-      <>
-        Vos données sont protégées. Consultez notre{' '}
-        <a
-          href="/privacy"
-          className="font-semibold text-[#139E9B] transition-colors hover:text-[#2280FF]"
-        >
-          Politique de confidentialité
-        </a>
-        .
-      </>
-    )
-  },
-  en: {
-    heading: 'The Automated SMB',
-    subheading: 'Your weekly playbook to modernize your SMB',
-    body:
-      'Every week, get actionable tactics to save time, cut costs, and stay compliant with Law 25. Clear insights, ready to use immediately.',
-    emailLabel: 'Email address',
-    emailPlaceholder: 'you@company.com',
-    consentLabel:
-      'I consent to receive communications from The Automated SMB and understand I can unsubscribe at any time.',
-    submit: 'Get the weekly newsletter',
-    successTitle: "Thanks! You're on the list.",
-    successBody: 'Look for the welcome email in your inbox within a few minutes.',
-    errorTitle: 'Oops! Something went wrong.',
-    errorBody: 'Please try again or email hello@simonparis.ca.',
-    trustLine: (
-      <>
-        Your data is protected. See our{' '}
-        <a
-          href="/privacy"
-          className="font-semibold text-[#139E9B] transition-colors hover:text-[#2280FF]"
-        >
-          Privacy Policy
-        </a>
-        .
-      </>
-    )
-  }
-} as const;
-
-export type SignupFormLang = keyof typeof copy;
-
-interface SignupFormProps {
-  lang: SignupFormLang;
-}
 
 const ensureHeadLink = (selector: string, create: () => HTMLLinkElement) => {
   let link = document.head.querySelector<HTMLLinkElement>(selector);
@@ -76,28 +14,24 @@ const ensureHeadLink = (selector: string, create: () => HTMLLinkElement) => {
   return link;
 };
 
-const ensureHeadScript = (selector: string, create: () => HTMLScriptElement) => {
-  let script = document.head.querySelector<HTMLScriptElement>(selector);
-  if (!script) {
-    script = create();
-    document.head.appendChild(script);
-  }
-  return script;
-};
+export type SignupFormLang = Extract<Language, 'fr' | 'en'>;
+
+interface SignupFormProps {
+  lang: SignupFormLang;
+}
 
 export const SignupForm: React.FC<SignupFormProps> = ({ lang }) => {
-  const t = copy[lang];
+  const signupCopy = translations[lang].newsletter.signup;
   const [sourceUrl, setSourceUrl] = useState('');
-  const emailFieldId = useId();
-  const consentFieldId = useId();
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
     setSourceUrl(window.location.href);
-  }, []);
+  }, [lang]);
 
   useEffect(() => {
     if (typeof document === 'undefined') return;
+
     ensureHeadLink("link[data-brevo='styles']", () => {
       const link = document.createElement('link');
       link.rel = 'stylesheet';
@@ -105,115 +39,119 @@ export const SignupForm: React.FC<SignupFormProps> = ({ lang }) => {
       link.dataset.brevo = 'styles';
       return link;
     });
-
-    ensureHeadScript("script[data-brevo='main']", () => {
-      const script = document.createElement('script');
-      script.src = 'https://sibforms.com/forms/end-form/build/main.js';
-      script.defer = true;
-      script.async = true;
-      script.dataset.brevo = 'main';
-      return script;
-    });
   }, []);
 
   useEffect(() => {
-    if (typeof document === 'undefined') return;
-    const selector = "script[data-recaptcha='loader']";
-    const existing = document.head.querySelector<HTMLScriptElement>(selector);
-    const scriptSrc = `https://www.google.com/recaptcha/api.js?render=${RECAPTCHA_SITE_KEY}&hl=${lang}`;
+    if (!import.meta.env.DEV) return;
+    if (typeof window === 'undefined' || typeof document === 'undefined') return;
 
-    if (existing) {
-      if (existing.src !== scriptSrc) {
-        existing.remove();
-      } else {
-        return;
-      }
-    }
-
-    ensureHeadScript(selector, () => {
-      const script = document.createElement('script');
-      script.src = scriptSrc;
-      script.defer = true;
-      script.async = true;
-      script.dataset.recaptcha = 'loader';
-      return script;
-    });
-  }, [lang]);
-
-  const localeValue = useMemo(() => lang, [lang]);
+    console.assert(!!document.querySelector('#sib-form'), 'sib-form not found');
+    console.assert(
+      typeof (window as unknown as { grecaptcha?: unknown }).grecaptcha !== 'undefined' || true,
+      'recaptcha not yet loaded'
+    );
+    console.assert(!!document.querySelector('#success-message'), 'success container missing');
+    console.assert(!!document.querySelector('#error-message'), 'error container missing');
+  }, []);
 
   return (
-    <section className="w-full">
-      <div className="mx-auto w-full max-w-[600px] rounded-[12px] bg-white p-8 shadow-[0_32px_80px_rgba(18,28,45,0.12)] ring-1 ring-black/5 sm:p-12">
-        <header className="mb-10 space-y-5 md:space-y-6">
-          <h1 className="text-3xl font-semibold text-[#121C2D] md:text-4xl">{t.heading}</h1>
-          <p className="text-lg font-medium text-[#1F2937] md:text-xl">{t.subheading}</p>
-          <p className="text-base leading-relaxed text-[#4B5563]">{t.body}</p>
-        </header>
+    <>
+      <section className="w-full font-inter">
+        <div className="mx-auto w-full max-w-[600px] rounded-[12px] bg-white/95 p-8 shadow-[0_32px_80px_rgba(18,28,45,0.12)] ring-1 ring-black/5 sm:p-12">
+          <header className="mb-10 space-y-5 md:space-y-6">
+            <h1 className="text-3xl font-semibold text-[#121C2D] md:text-4xl">{signupCopy.heading}</h1>
+            <p className="text-lg font-semibold text-[#139E9C] md:text-xl">{signupCopy.subheading}</p>
+            <p className="text-base leading-relaxed text-[#4B5563]">{signupCopy.body}</p>
+          </header>
 
-        <form method="POST" action={POST_URL} className="space-y-6" noValidate>
-          <div className="space-y-2">
-            <label htmlFor={emailFieldId} className="text-sm font-semibold text-[#1F2937]">
-              {t.emailLabel}
-            </label>
-            <input
-              id={emailFieldId}
-              name="EMAIL"
-              type="email"
-              required
-              placeholder={t.emailPlaceholder}
-              className="w-full rounded-[10px] border border-[#D1D5DB] bg-white px-5 py-3 text-base font-inter text-[#121C2D] shadow-sm transition focus:border-[#139E9B] focus:outline-none focus:ring-4 focus:ring-[#139E9B]/20"
-            />
-          </div>
-
-          <div className="flex items-start gap-3">
-            <input
-              id={consentFieldId}
-              name="OPT_IN"
-              type="checkbox"
-              required
-              className="mt-1 h-5 w-5 rounded border-[#D1D5DB] text-[#139E9B] focus:ring-[#139E9B]"
-            />
-            <label htmlFor={consentFieldId} className="text-sm leading-relaxed text-[#4B5563]">
-              {t.consentLabel}
-            </label>
-          </div>
-
-          <div
-            aria-live="assertive"
-            id="error-message"
-            className="hidden rounded-[8px] border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+          <form
+            id="sib-form"
+            data-type="subscription"
+            method="POST"
+            action={POST_URL}
+            className="space-y-6"
           >
-            <p className="font-semibold">{t.errorTitle}</p>
-            <p className="mt-1 leading-relaxed">{t.errorBody}</p>
-          </div>
-          <div
-            aria-live="polite"
-            id="success-message"
-            className="hidden rounded-[8px] border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700"
-          >
-            <p className="font-semibold">{t.successTitle}</p>
-            <p className="mt-1 leading-relaxed">{t.successBody}</p>
-          </div>
+            <div className="space-y-2">
+              <label htmlFor="EMAIL" className="text-sm font-semibold text-[#1F2937]">
+                {signupCopy.emailLabel}
+              </label>
+              <input
+                id="EMAIL"
+                name="EMAIL"
+                type="email"
+                required
+                placeholder={signupCopy.emailPlaceholder}
+                autoComplete="email"
+                className="w-full rounded-[10px] border border-[#D1D5DB] bg-white px-5 py-3 text-base text-[#121C2D] shadow-sm transition focus:border-[#139E9C] focus:outline-none focus:ring-4 focus:ring-[#139E9C]/20"
+              />
+            </div>
 
-          <input type="text" name="email_address_check" className="input--hidden" defaultValue="" tabIndex={-1} autoComplete="off" />
-          <input type="hidden" name="LANGUAGE" value={lang} />
-          <input type="hidden" name="locale" value={localeValue} />
-          {sourceUrl && <input type="hidden" name="SOURCE_URL" value={sourceUrl} />}
+            <div className="flex items-start gap-3">
+              <input
+                id="OPT_IN"
+                name="OPT_IN"
+                type="checkbox"
+                value="1"
+                required
+                className="mt-1 h-5 w-5 rounded border-[#D1D5DB] text-[#139E9C] focus:ring-[#139E9C]"
+              />
+              <label htmlFor="OPT_IN" className="text-sm leading-relaxed text-[#4B5563]">
+                {signupCopy.consentLabel}
+              </label>
+            </div>
 
-          <div className="g-recaptcha-v3" data-sitekey={RECAPTCHA_SITE_KEY} style={{ display: 'none' }} />
+            <div
+              id="error-message"
+              aria-live="assertive"
+              style={{ display: 'none' }}
+              className="rounded-[8px] border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+            >
+              <p className="font-semibold">{signupCopy.errorTitle}</p>
+              <p className="mt-1 leading-relaxed">{signupCopy.errorBody}</p>
+            </div>
 
-          <button
-            type="submit"
-            className="btn-primary w-full"
-          >
-            {t.submit}
-          </button>
-        </form>
+            <div
+              id="success-message"
+              aria-live="polite"
+              style={{ display: 'none' }}
+              className="rounded-[8px] border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700"
+            >
+              <p className="font-semibold">{signupCopy.successTitle}</p>
+              <p className="mt-1 leading-relaxed">{signupCopy.successBody}</p>
+            </div>
 
-        <p className="mt-8 text-sm text-[#6B7280]">{t.trustLine}</p>
-      </div>
-    </section>
+            <input type="text" name="email_address_check" value="" className="hidden" />
+            <input type="hidden" name="LANGUAGE" value={lang} />
+            <input type="hidden" name="locale" value={lang} />
+            <input type="hidden" name="SOURCE_URL" value={sourceUrl} />
+
+            <div className="g-recaptcha-v3" data-sitekey={RECAPTCHA_SITE_KEY} style={{ display: 'none' }} />
+
+            <button type="submit" className="btn-primary w-full">
+              {signupCopy.submit}
+            </button>
+          </form>
+
+          <p className="mt-8 text-sm text-[#6B7280]">
+            {signupCopy.trustLine.prefix}
+            <a
+              href={lang === 'fr' ? '/fr/politique-confidentialite' : '/privacy'}
+              className="font-semibold text-[#139E9C] transition-colors hover:text-[#0F807E]"
+            >
+              {signupCopy.trustLine.linkLabel}
+            </a>
+            {signupCopy.trustLine.suffix}
+          </p>
+        </div>
+      </section>
+
+      <script defer src="https://sibforms.com/forms/end-form/build/main.js"></script>
+      <script
+        src={`https://www.google.com/recaptcha/api.js?render=${RECAPTCHA_SITE_KEY}&hl=${lang}`}
+        async
+        defer
+      ></script>
+    </>
   );
 };
 

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -5,7 +5,7 @@ export const en = {
     brand: 'Simon Paris',
     languageToggle: 'EN/FR',
     email: 'info@simonparis.ca',
-    cta: 'Download Checklist'
+    cta: 'Join newsletter'
   },
   hero: {
     eyebrow: 'For Québec clinics • Law 25 + Bill 96 ready',
@@ -15,7 +15,7 @@ export const en = {
       'Plug‑and‑play bilingual automations for Speed‑to‑Lead, No‑Show Chaser, and Review Engine—built for Québec clinics. Demo first. Install in minutes.',
       proof:
         'Clinics that automate often see 25–50% fewer no‑shows and much faster follow‑ups.',
-      primaryCta: 'Download the Checklist'
+      primaryCta: 'Join newsletter'
     },
   problems: {
     title: 'Why clinics <span class="accent">lose money</span> every week…',
@@ -81,17 +81,17 @@ export const en = {
     disclaimer: 'Estimates based on ~$120–150 per appointment and typical lead leakage in Québec. Results vary.'
   },
   checklist: {
-    eyebrow: 'Free',
+    eyebrow: 'Weekly Briefing',
     title: 'Are you really <span class="accent">Law 25</span> ready?',
-    sub: 'Most clinics think they’re fine… until a no-show patient or audit proves otherwise. Download the free checklist to spot the hidden risks in your communication workflows.',
-      points: [
-        'Is your SMS & email consent wording valid under Québec law?',
-        'Do you have timestamped proof for every message you send?',
-        'Are your reminders and follow-ups fully FR-first?',
-        'Can patients opt-out instantly, without risk of complaint?'
-      ],
-    cta: 'Download the Checklist',
-    href: '/checklist'
+    sub: 'Most clinics think they’re fine… until a no-show patient or audit proves otherwise. Join the weekly briefing to spot the hidden risks before they become costly.',
+    points: [
+      'Is your SMS & email consent wording valid under Québec law?',
+      'Do you have timestamped proof for every message you send?',
+      'Are your reminders and follow-ups fully FR-first?',
+      'Can patients opt-out instantly, without risk of complaint?'
+    ],
+    cta: 'Join newsletter',
+    href: '/en/newsletter'
   },
   proof: {
     title: 'Clinics that automate see results fast.',
@@ -142,14 +142,14 @@ export const en = {
     ]
   },
   finalCTA: {
-    title: 'Start Free. Stay Compliant. Grow Faster.',
-    sub: 'Download the checklist now — upgrade to packs when ready.',
-    primary: 'Download Checklist',
-    primaryHref: '/checklist',
+    title: 'Stay compliant. Stay ahead.',
+    sub: 'Join the weekly newsletter for proven automation tactics built for Québec SMBs.',
+    primary: 'Join newsletter',
+    primaryHref: '/en/newsletter',
     secondary: 'See Packs',
     secondaryHref: '/packs'
   },
-  stickyCta: 'Download the Checklist',
+  stickyCta: 'Join newsletter',
   trustBadge: 'Built for Québec • Demo-first • Fully bilingual & Law 96\u2013compliant',
   partners: {
     title: 'Trusted & Supported By'
@@ -162,40 +162,33 @@ export const en = {
       canonical: '/en/newsletter',
       alternate: '/fr/newsletter'
     },
-    signup: {
-      heading: 'Québec SMB AI Newsletter — The Automated SMB',
-      subheading: 'Your weekly briefing on automation and AI',
-      body:
-        'Every week, get clear, actionable insights to save time, cut costs, and stay compliant with Law 25. No jargon — just practical tactics designed for Québec SMBs.',
-      emailLabel: 'Email address',
-      emailPlaceholder: 'you@company.com',
-      consentLabel:
-        'I consent to receive communications from The Automated SMB and understand I can unsubscribe at any time.',
-      submit: 'Get the weekly newsletter',
-      successTitle: "Thanks! You're on the list.",
-      successBody: 'Watch your inbox for the welcome email within the next few minutes.',
-      errorTitle: 'Something needs your attention',
-      errorBody: 'Check your details and try again, or email hello@simonparis.ca for support.',
-      trustLine: {
-        prefix: 'Your data is protected. See our ',
-        linkLabel: 'Privacy Policy',
-        suffix: '.'
-      }
+    title: 'The Automated SMB – The pragmatic newsletter for modernizing your SMB',
+    subtitle: 'Every week: save time and discover practical AI tools for SMBs.',
+    body:
+      'Actionable tactics to streamline operations and cut compliance risk every week.\nBuilt for Québec SMB leaders who need trusted, bilingual guidance.',
+    emailLabel: 'Email address',
+    emailPlaceholder: 'name@business.com',
+    consent: 'Yes, I want to receive The Automated SMB and stay compliant with Law 25.',
+    submit: 'Get the weekly newsletter',
+    trust: '🔒 Your data is protected. See our Privacy Policy.',
+    success: {
+      title: "Thanks! You're on the list.",
+      body: 'Watch your inbox for the welcome email within the next few minutes.'
+    },
+    error: {
+      title: 'Something needs your attention',
+      body: 'Check your details and try again, or email hello@simonparis.ca for support.'
     },
     confirmation: {
-      metaTitle: 'Newsletter Confirmation | The Automated SMB',
-      heading: "You're almost subscribed",
-      subheading: 'Confirm your weekly briefing',
-      intro:
-        'Open the confirmation email we just sent. Click the validation button so we can start sending your weekly briefing.',
-      checklist: [
-        'Look for an email from The Automated SMB in your inbox or promotions tab.',
-        'Click the confirmation button to activate your subscription.',
-        'Add us to your safe senders list so the briefing never gets lost.'
-      ],
-      ctaLabel: 'Back to the homepage',
-      ctaHref: '/',
-      support: 'Need help? Email hello@simonparis.ca.'
+      metaTitle: 'Newsletter confirmation | The Automated SMB',
+      title: 'Subscription confirmed',
+      body:
+        'Thank you! Your subscription is confirmed. You’ll now receive weekly practical insights to modernize your SMB.',
+      extra: '👉 Add us to your safe senders list so you never miss an issue.',
+      backHome: {
+        label: 'Back to homepage',
+        href: '/en'
+      }
     }
   },
   footer: {

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -154,6 +154,50 @@ export const en = {
   partners: {
     title: 'Trusted & Supported By'
   },
+  newsletter: {
+    meta: {
+      title: 'Québec SMB AI Newsletter | The Automated SMB',
+      description:
+        'Weekly newsletter for Québec SMBs: save time, cut costs, and stay compliant with Law 25.',
+      canonical: '/en/newsletter',
+      alternate: '/fr/newsletter'
+    },
+    signup: {
+      heading: 'Québec SMB AI Newsletter — The Automated SMB',
+      subheading: 'Your weekly briefing on automation and AI',
+      body:
+        'Every week, get clear, actionable insights to save time, cut costs, and stay compliant with Law 25. No jargon — just practical tactics designed for Québec SMBs.',
+      emailLabel: 'Email address',
+      emailPlaceholder: 'you@company.com',
+      consentLabel:
+        'I consent to receive communications from The Automated SMB and understand I can unsubscribe at any time.',
+      submit: 'Get the weekly newsletter',
+      successTitle: "Thanks! You're on the list.",
+      successBody: 'Watch your inbox for the welcome email within the next few minutes.',
+      errorTitle: 'Something needs your attention',
+      errorBody: 'Check your details and try again, or email hello@simonparis.ca for support.',
+      trustLine: {
+        prefix: 'Your data is protected. See our ',
+        linkLabel: 'Privacy Policy',
+        suffix: '.'
+      }
+    },
+    confirmation: {
+      metaTitle: 'Newsletter Confirmation | The Automated SMB',
+      heading: "You're almost subscribed",
+      subheading: 'Confirm your weekly briefing',
+      intro:
+        'Open the confirmation email we just sent. Click the validation button so we can start sending your weekly briefing.',
+      checklist: [
+        'Look for an email from The Automated SMB in your inbox or promotions tab.',
+        'Click the confirmation button to activate your subscription.',
+        'Add us to your safe senders list so the briefing never gets lost.'
+      ],
+      ctaLabel: 'Back to the homepage',
+      ctaHref: '/',
+      support: 'Need help? Email hello@simonparis.ca.'
+    }
+  },
   footer: {
     blurb: "Bilingual automation for Québec SMBs. Built for today's needs, ready for tomorrow's AI.",
     language: 'Serving all of Québec • EN/FR',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -162,11 +162,11 @@ export const en = {
       canonical: '/en/newsletter',
       alternate: '/fr/newsletter'
     },
-    title: 'The Automated SMB – The pragmatic newsletter for modernizing your SMB',
-    subtitle: 'Every week: save time and discover practical AI tools for SMBs.',
+    title: 'The Automated SMB',
+    subtitle: 'The pragmatic newsletter to modernize your SMB',
     bodyLines: [
-      'Clear, actionable tactics designed for Québec SMB leaders.',
-      'Stay compliant with Law 25 and cut costs without the jargon.'
+      'Every week: save time and cut costly mistakes.',
+      'Clear, practical tips for Québec SMBs that stay compliant with Law 25.'
     ],
     emailLabel: 'Email address',
     emailPlaceholder: 'name@business.com',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -5,7 +5,7 @@ export const en = {
     brand: 'Simon Paris',
     languageToggle: 'EN/FR',
     email: 'info@simonparis.ca',
-    cta: 'Join newsletter'
+    cta: 'Join Newsletter'
   },
   hero: {
     eyebrow: 'For Québec clinics • Law 25 + Bill 96 ready',
@@ -13,10 +13,10 @@ export const en = {
     h1_accent: 'Stay 100% Compliant.',
     subhead:
       'Plug‑and‑play bilingual automations for Speed‑to‑Lead, No‑Show Chaser, and Review Engine—built for Québec clinics. Demo first. Install in minutes.',
-      proof:
-        'Clinics that automate often see 25–50% fewer no‑shows and much faster follow‑ups.',
-      primaryCta: 'Join newsletter'
-    },
+    proof:
+      'Clinics that automate often see 25–50% fewer no‑shows and much faster follow‑ups.',
+    primaryCta: 'Join Newsletter'
+  },
   problems: {
     title: 'Why clinics <span class="accent">lose money</span> every week…',
       list: [
@@ -90,7 +90,7 @@ export const en = {
       'Are your reminders and follow-ups fully FR-first?',
       'Can patients opt-out instantly, without risk of complaint?'
     ],
-    cta: 'Join newsletter',
+    cta: 'Join Newsletter',
     href: '/en/newsletter'
   },
   proof: {
@@ -144,12 +144,12 @@ export const en = {
   finalCTA: {
     title: 'Stay compliant. Stay ahead.',
     sub: 'Join the weekly newsletter for proven automation tactics built for Québec SMBs.',
-    primary: 'Join newsletter',
+    primary: 'Join Newsletter',
     primaryHref: '/en/newsletter',
     secondary: 'See Packs',
     secondaryHref: '/packs'
   },
-  stickyCta: 'Join newsletter',
+  stickyCta: 'Join Newsletter',
   trustBadge: 'Built for Québec • Demo-first • Fully bilingual & Law 96\u2013compliant',
   partners: {
     title: 'Trusted & Supported By'
@@ -164,13 +164,20 @@ export const en = {
     },
     title: 'The Automated SMB – The pragmatic newsletter for modernizing your SMB',
     subtitle: 'Every week: save time and discover practical AI tools for SMBs.',
-    body:
-      'Actionable tactics to streamline operations and cut compliance risk every week.\nBuilt for Québec SMB leaders who need trusted, bilingual guidance.',
+    bodyLines: [
+      'Clear, actionable tactics designed for Québec SMB leaders.',
+      'Stay compliant with Law 25 and cut costs without the jargon.'
+    ],
     emailLabel: 'Email address',
     emailPlaceholder: 'name@business.com',
-    consent: 'Yes, I want to receive The Automated SMB and stay compliant with Law 25.',
+    consent:
+      'I consent to receive communications from The Automated SMB and understand I can unsubscribe at any time.',
     submit: 'Get the weekly newsletter',
-    trust: '🔒 Your data is protected. See our Privacy Policy.',
+    trust: {
+      prefix: 'Your data is protected. See our ',
+      linkLabel: 'Privacy Policy',
+      suffix: '.'
+    },
     success: {
       title: "Thanks! You're on the list.",
       body: 'Watch your inbox for the welcome email within the next few minutes.'

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -164,13 +164,20 @@ const fr: TranslationKeys = {
     },
     title: 'The Automated SMB – L’infolettre pragmatique pour moderniser votre PME',
     subtitle: 'Chaque semaine : gagnez du temps et découvrez des outils IA concrets pour PME.',
-    body:
-      'Tactiques hebdomadaires pour gagner du temps et réduire vos coûts, sans jargon.\nPensées pour les dirigeants de PME québécoises qui veulent rester conformes à la Loi 25.',
+    bodyLines: [
+      'Des conseils clairs et applicables dès maintenant.',
+      'Pensés pour les dirigeants de PME québécoises qui veulent rester conformes à la Loi 25.'
+    ],
     emailLabel: 'Adresse courriel',
     emailPlaceholder: 'nom@entreprise.com',
-    consent: 'Oui, je veux recevoir l’Hebdo IA Québec et rester conforme à la Loi 25.',
+    consent:
+      'Je consens à recevoir les communications de The Automated SMB et je comprends que je peux me désabonner en tout temps.',
     submit: 'Recevoir l’infolettre chaque semaine',
-    trust: '🔒 Vos données sont protégées. Consultez notre Politique de confidentialité.',
+    trust: {
+      prefix: 'Vos données sont protégées. Consultez notre ',
+      linkLabel: 'Politique de confidentialité',
+      suffix: '.'
+    },
     success: {
       title: 'Merci! Votre inscription est prise en compte.',
       body: 'Surveillez votre boîte de réception : un courriel de bienvenue arrive sous peu.'

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -162,11 +162,11 @@ const fr: TranslationKeys = {
       canonical: '/fr/newsletter',
       alternate: '/en/newsletter'
     },
-    title: 'The Automated SMB – L’infolettre pragmatique pour moderniser votre PME',
-    subtitle: 'Chaque semaine : gagnez du temps et découvrez des outils IA concrets pour PME.',
+    title: 'The Automated SMB',
+    subtitle: 'L’infolettre pragmatique pour moderniser votre PME',
     bodyLines: [
-      'Des conseils clairs et applicables dès maintenant.',
-      'Pensés pour les dirigeants de PME québécoises qui veulent rester conformes à la Loi 25.'
+      'Chaque semaine : gagnez du temps et évitez les erreurs coûteuses.',
+      'Des conseils clairs, pensés pour les PME québécoises et conformes à la Loi 25.'
     ],
     emailLabel: 'Adresse courriel',
     emailPlaceholder: 'nom@entreprise.com',

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -154,6 +154,50 @@ const fr: TranslationKeys = {
   partners: {
     title: 'Partenaires de confiance'
   },
+  newsletter: {
+    meta: {
+      title: 'Infolettre PME Québec | The Automated SMB',
+      description:
+        'Infolettre hebdo pour les PME québécoises : gagnez du temps, réduisez vos coûts et restez conforme à la Loi 25.',
+      canonical: '/fr/newsletter',
+      alternate: '/en/newsletter'
+    },
+    signup: {
+      heading: 'Infolettre PME Québec — The Automated SMB',
+      subheading: 'Votre rendez-vous hebdo avec l’automatisation et l’IA',
+      body:
+        'Chaque semaine, recevez des conseils concrets pour gagner du temps, réduire vos coûts et rester conforme à la Loi 25. Des tactiques simples, pensées pour les PME québécoises — applicables dès maintenant.',
+      emailLabel: 'Adresse courriel',
+      emailPlaceholder: 'prenom@entreprise.com',
+      consentLabel:
+        'Je consens à recevoir les communications de The Automated SMB et je comprends que je peux me désabonner en tout temps.',
+      submit: 'Recevoir l’infolettre chaque semaine',
+      successTitle: 'Merci! Votre inscription est prise en compte.',
+      successBody: 'Surveillez votre boîte de réception : un courriel de bienvenue arrive sous peu.',
+      errorTitle: 'Une vérification est nécessaire',
+      errorBody: 'Vérifiez vos informations et réessayez, ou écrivez-nous à hello@simonparis.ca.',
+      trustLine: {
+        prefix: 'Vos données sont protégées. Consultez notre ',
+        linkLabel: 'Politique de confidentialité',
+        suffix: '.'
+      }
+    },
+    confirmation: {
+      metaTitle: 'Confirmation infolettre | The Automated SMB',
+      heading: 'Vous y êtes presque',
+      subheading: 'Confirmez votre rendez-vous hebdo',
+      intro:
+        'Ouvrez le courriel de confirmation que nous venons d’envoyer. Cliquez sur le bouton pour activer l’envoi de votre infolettre hebdo.',
+      checklist: [
+        'Repérez le courriel de The Automated SMB dans votre boîte de réception ou vos indésirables.',
+        'Cliquez sur le bouton de confirmation pour finaliser votre inscription.',
+        'Ajoutez-nous à vos expéditeurs sûrs pour ne rien manquer.'
+      ],
+      ctaLabel: 'Retour à l’accueil',
+      ctaHref: '/fr',
+      support: 'Besoin d’aide? Écrivez à hello@simonparis.ca.'
+    }
+  },
   footer: {
     blurb: 'Automatisation bilingue pour les PME du Québec. Conçu pour aujourd’hui, prêt pour l’IA de demain.',
     language: 'Pour tout le Québec • FR/EN',

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -6,7 +6,7 @@ const fr: TranslationKeys = {
     brand: 'Simon Paris',
     languageToggle: 'FR/EN',
     email: 'info@simonparis.ca',
-    cta: 'Télécharger la checklist'
+    cta: 'Joindre l’infolettre'
   },
   hero: {
     eyebrow: 'Pour les cliniques du Québec • Prêt Loi 25 + Loi 96',
@@ -15,7 +15,7 @@ const fr: TranslationKeys = {
     subhead:
       'Automatisations bilingues prêtes à l’emploi pour vitesse‑à‑lead, relance d’absences et moteur d’avis — conçues pour les cliniques du Québec. Démo d’abord. Installation en minutes.',
     proof: 'Les cliniques qui automatisent voient souvent 25–50 % moins d’absences et des suivis beaucoup plus rapides.',
-    primaryCta: 'Télécharger la checklist de conformité'
+    primaryCta: 'Joindre l’infolettre'
   },
   problems: {
     title: 'Pourquoi les cliniques <span class="accent">perdent de l’argent</span> chaque semaine…',
@@ -81,17 +81,17 @@ const fr: TranslationKeys = {
     disclaimer: 'Estimations basées sur ~120–150 $ par rendez‑vous et des pertes typiques de leads au Québec. Résultats variables.'
   },
   checklist: {
-    eyebrow: 'Gratuit',
+    eyebrow: 'Hebdo IA',
     title: 'Êtes-vous vraiment prêt pour la <span class="accent">Loi 25</span>?',
-    sub: 'La plupart des cliniques croient que oui… jusqu’à ce qu’un patient manqué ou un audit révèle le contraire. Téléchargez la liste gratuite pour découvrir les zones à risque dans vos communications.',
-      points: [
-        'Vos formulaires de consentement pour SMS et courriels sont-ils vraiment conformes?',
-        'Avez-vous une preuve horodatée de chaque message envoyé?',
-        'Vos rappels et suivis sont-ils 100 % en français d’abord (FR-first)?',
-        'Vos patients peuvent-ils se désabonner instantanément, sans plainte possible?'
-      ],
-    cta: 'Télécharger la Liste',
-    href: '/checklist'
+    sub: 'La plupart des cliniques croient que oui… jusqu’à ce qu’un absent ou un audit révèle le contraire. Joignez l’infolettre hebdo pour repérer les failles avant qu’elles ne coûtent cher.',
+    points: [
+      'Vos formulaires de consentement pour SMS et courriels sont-ils vraiment conformes?',
+      'Avez-vous une preuve horodatée de chaque message envoyé?',
+      'Vos rappels et suivis sont-ils 100 % en français d’abord (FR-first)?',
+      'Vos patients peuvent-ils se désabonner instantanément, sans plainte possible?'
+    ],
+    cta: 'Joindre l’infolettre',
+    href: '/fr/newsletter'
   },
   proof: {
     title: 'Les cliniques qui automatisent voient des résultats rapides.',
@@ -142,14 +142,14 @@ const fr: TranslationKeys = {
     ]
   },
   finalCTA: {
-    title: 'Commencez gratuitement. Restez conforme. Croissez plus vite.',
-    sub: 'Téléchargez la checklist maintenant — passez aux packs quand vous serez prêt.',
-    primary: 'Télécharger la checklist',
-    primaryHref: '/checklist',
+    title: 'Restez conforme. Restez en avance.',
+    sub: 'Rejoignez l’infolettre hebdo pour des tactiques d’automatisation pensées pour les PME québécoises.',
+    primary: 'Joindre l’infolettre',
+    primaryHref: '/fr/newsletter',
     secondary: 'Voir les packs',
     secondaryHref: '/packs'
   },
-  stickyCta: 'Télécharger la checklist',
+  stickyCta: 'Joindre l’infolettre',
   trustBadge: 'Conçu pour le Québec • Démo en direct • Bilingue et conforme à la Loi 96',
   partners: {
     title: 'Partenaires de confiance'
@@ -162,40 +162,33 @@ const fr: TranslationKeys = {
       canonical: '/fr/newsletter',
       alternate: '/en/newsletter'
     },
-    signup: {
-      heading: 'Infolettre PME Québec — The Automated SMB',
-      subheading: 'Votre rendez-vous hebdo avec l’automatisation et l’IA',
-      body:
-        'Chaque semaine, recevez des conseils concrets pour gagner du temps, réduire vos coûts et rester conforme à la Loi 25. Des tactiques simples, pensées pour les PME québécoises — applicables dès maintenant.',
-      emailLabel: 'Adresse courriel',
-      emailPlaceholder: 'prenom@entreprise.com',
-      consentLabel:
-        'Je consens à recevoir les communications de The Automated SMB et je comprends que je peux me désabonner en tout temps.',
-      submit: 'Recevoir l’infolettre chaque semaine',
-      successTitle: 'Merci! Votre inscription est prise en compte.',
-      successBody: 'Surveillez votre boîte de réception : un courriel de bienvenue arrive sous peu.',
-      errorTitle: 'Une vérification est nécessaire',
-      errorBody: 'Vérifiez vos informations et réessayez, ou écrivez-nous à hello@simonparis.ca.',
-      trustLine: {
-        prefix: 'Vos données sont protégées. Consultez notre ',
-        linkLabel: 'Politique de confidentialité',
-        suffix: '.'
-      }
+    title: 'The Automated SMB – L’infolettre pragmatique pour moderniser votre PME',
+    subtitle: 'Chaque semaine : gagnez du temps et découvrez des outils IA concrets pour PME.',
+    body:
+      'Tactiques hebdomadaires pour gagner du temps et réduire vos coûts, sans jargon.\nPensées pour les dirigeants de PME québécoises qui veulent rester conformes à la Loi 25.',
+    emailLabel: 'Adresse courriel',
+    emailPlaceholder: 'nom@entreprise.com',
+    consent: 'Oui, je veux recevoir l’Hebdo IA Québec et rester conforme à la Loi 25.',
+    submit: 'Recevoir l’infolettre chaque semaine',
+    trust: '🔒 Vos données sont protégées. Consultez notre Politique de confidentialité.',
+    success: {
+      title: 'Merci! Votre inscription est prise en compte.',
+      body: 'Surveillez votre boîte de réception : un courriel de bienvenue arrive sous peu.'
+    },
+    error: {
+      title: 'Une vérification est nécessaire',
+      body: 'Vérifiez vos informations et réessayez, ou écrivez-nous à hello@simonparis.ca.'
     },
     confirmation: {
       metaTitle: 'Confirmation infolettre | The Automated SMB',
-      heading: 'Vous y êtes presque',
-      subheading: 'Confirmez votre rendez-vous hebdo',
-      intro:
-        'Ouvrez le courriel de confirmation que nous venons d’envoyer. Cliquez sur le bouton pour activer l’envoi de votre infolettre hebdo.',
-      checklist: [
-        'Repérez le courriel de The Automated SMB dans votre boîte de réception ou vos indésirables.',
-        'Cliquez sur le bouton de confirmation pour finaliser votre inscription.',
-        'Ajoutez-nous à vos expéditeurs sûrs pour ne rien manquer.'
-      ],
-      ctaLabel: 'Retour à l’accueil',
-      ctaHref: '/fr',
-      support: 'Besoin d’aide? Écrivez à hello@simonparis.ca.'
+      title: 'Inscription confirmée',
+      body:
+        'Merci! Votre inscription à l’infolettre est confirmée. Vous recevrez chaque semaine des conseils pratiques pour moderniser votre PME.',
+      extra: '👉 Ajoutez-nous à vos expéditeurs sûrs pour ne rien manquer.',
+      backHome: {
+        label: 'Retour à l’accueil',
+        href: '/fr'
+      }
     }
   },
   footer: {

--- a/src/index.css
+++ b/src/index.css
@@ -46,6 +46,13 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+.input--hidden {
+  position: absolute !important;
+  left: -5000px;
+  opacity: 0;
+  pointer-events: none;
+}
+
 h1, h2, h3, h4, h5, h6 {
   font-family: 'Montserrat', sans-serif;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -46,6 +46,18 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+input,
+textarea,
+select {
+  font-family: 'Inter', sans-serif;
+}
+
+input::placeholder,
+textarea::placeholder {
+  font-family: 'Inter', sans-serif;
+  color: #9CA3AF;
+}
+
 .input--hidden {
   position: absolute !important;
   left: -5000px;
@@ -196,6 +208,23 @@ h1, h2, h3, h4, h5, h6 {
   background: #2280FF;
   color: white;
   transform: translateY(-1px);
+}
+
+.grecaptcha-badge {
+  position: fixed !important;
+  bottom: 40px !important;
+  right: 40px !important;
+  z-index: 50 !important;
+  box-shadow: 0 12px 32px rgba(18, 28, 45, 0.25) !important;
+  border-radius: 9999px !important;
+  overflow: hidden !important;
+}
+
+@media (max-width: 640px) {
+  .grecaptcha-badge {
+    bottom: 16px !important;
+    right: 16px !important;
+  }
 }
 
 /* Premium Cards */

--- a/src/index.css
+++ b/src/index.css
@@ -36,7 +36,7 @@ html {
 }
 
 body {
-  font-family: 'Open Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   font-feature-settings: 'cv02', 'cv03', 'cv04', 'cv11';
   line-height: 1.6;
   color: var(--text-primary);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -27,6 +27,8 @@ if (path === '/privacy') {
   Component = NewsletterEN;
 } else if (path === '/newsletter/confirmation') {
   Component = NewsletterConfirmation;
+} else if (path === '/en') {
+  Component = App;
 }
 
 createRoot(document.getElementById('root')!).render(

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import PrivacyPolicy from './pages/PrivacyPolicy';
 import PolitiqueConfidentialite from './pages/PolitiqueConfidentialite';
 import { LandingEN, LandingFR } from './pages/SpeedToLead';
 import { NewsletterEN, NewsletterFR } from './pages/NewsletterPage';
+import NewsletterConfirmation from './pages/NewsletterConfirmation';
 import { LanguageProvider } from './LanguageProvider';
 import './index.css';
 
@@ -24,6 +25,8 @@ if (path === '/privacy') {
   Component = NewsletterFR;
 } else if (path === '/en/newsletter') {
   Component = NewsletterEN;
+} else if (path === '/newsletter/confirmation') {
+  Component = NewsletterConfirmation;
 }
 
 createRoot(document.getElementById('root')!).render(

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import App from './App.tsx';
 import PrivacyPolicy from './pages/PrivacyPolicy';
 import PolitiqueConfidentialite from './pages/PolitiqueConfidentialite';
 import { LandingEN, LandingFR } from './pages/SpeedToLead';
+import { NewsletterEN, NewsletterFR } from './pages/NewsletterPage';
 import { LanguageProvider } from './LanguageProvider';
 import './index.css';
 
@@ -19,6 +20,10 @@ if (path === '/privacy') {
   Component = LandingEN;
 } else if (path === '/fr/ne-manquez-aucun-patient') {
   Component = LandingFR;
+} else if (path === '/fr/newsletter') {
+  Component = NewsletterFR;
+} else if (path === '/en/newsletter') {
+  Component = NewsletterEN;
 }
 
 createRoot(document.getElementById('root')!).render(

--- a/src/pages/NewsletterConfirmation.tsx
+++ b/src/pages/NewsletterConfirmation.tsx
@@ -38,7 +38,7 @@ const NewsletterConfirmation: React.FC = () => {
       robots.name = 'robots';
       document.head.appendChild(robots);
     }
-    robots.content = 'noindex';
+    robots.content = 'noindex, nofollow';
   }, [copy.metaTitle]);
 
   return (
@@ -49,27 +49,15 @@ const NewsletterConfirmation: React.FC = () => {
           en: translations.en.newsletter.meta.canonical
         }}
         forceDarkBackground
-        ctaHref={resolvedLang === 'fr' ? '/fr#hero' : '/#hero'}
       />
       <main className="flex flex-1 items-center justify-center px-4 py-24 md:px-6">
-        <div className="w-full max-w-[560px] rounded-[16px] bg-white/95 p-10 shadow-[0_28px_72px_rgba(18,28,45,0.12)] ring-1 ring-black/5">
-          <h1 className="text-3xl font-semibold text-[#121C2D] md:text-4xl">{copy.heading}</h1>
-          <p className="mt-4 text-lg font-semibold text-[#139E9C]">{copy.subheading}</p>
-          <p className="mt-6 text-base leading-relaxed text-[#4B5563]">{copy.intro}</p>
-          <ul className="mt-6 space-y-3 text-base leading-relaxed text-[#4B5563]">
-            {copy.checklist.map(item => (
-              <li key={item} className="flex items-start gap-3">
-                <span className="mt-2 h-2 w-2 rounded-full bg-[#139E9C]" aria-hidden="true" />
-                <span>{item}</span>
-              </li>
-            ))}
-          </ul>
-          <div className="mt-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-            <a href={copy.ctaHref} className="btn-primary w-full sm:w-auto">
-              {copy.ctaLabel}
-            </a>
-            <p className="text-sm text-[#6B7280] sm:text-right">{copy.support}</p>
-          </div>
+        <div className="w-full max-w-[540px] rounded-[12px] bg-white/95 p-10 shadow-[0_28px_72px_rgba(18,28,45,0.12)] ring-1 ring-black/5 sm:p-12 font-inter">
+          <h1 className="text-3xl font-semibold text-[#121C2D] md:text-4xl">{copy.title}</h1>
+          <p className="mt-4 text-base leading-relaxed text-[#4B5563]">{copy.body}</p>
+          <p className="mt-6 text-sm font-medium text-[#139E9C]">{copy.extra}</p>
+          <a href={copy.backHome.href} className="btn-primary mt-10 inline-flex w-full justify-center sm:w-auto">
+            {copy.backHome.label}
+          </a>
         </div>
       </main>
       <Footer

--- a/src/pages/NewsletterConfirmation.tsx
+++ b/src/pages/NewsletterConfirmation.tsx
@@ -1,0 +1,85 @@
+import React, { useEffect, useState } from 'react';
+import { Header, Footer } from '../components/Layout';
+import { useLanguage } from '../LanguageProvider';
+import { translations, type Language } from '../i18n';
+
+const resolveLanguage = (searchParams: URLSearchParams, storageValue: string | null): Extract<Language, 'fr' | 'en'> => {
+  const paramLang = searchParams.get('lang');
+  if (paramLang === 'fr' || paramLang === 'en') {
+    return paramLang;
+  }
+  if (storageValue === 'fr' || storageValue === 'en') {
+    return storageValue;
+  }
+  return 'en';
+};
+
+const NewsletterConfirmation: React.FC = () => {
+  const { setLang } = useLanguage();
+  const [resolvedLang, setResolvedLang] = useState<Extract<Language, 'fr' | 'en'>>('en');
+  const copy = translations[resolvedLang].newsletter.confirmation;
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const params = new URLSearchParams(window.location.search);
+    const stored = window.localStorage.getItem('newsletter_lang');
+    const lang = resolveLanguage(params, stored);
+    setResolvedLang(lang);
+    setLang(lang);
+    window.localStorage.setItem('newsletter_lang', lang);
+  }, [setLang]);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    document.title = copy.metaTitle;
+    let robots = document.head.querySelector<HTMLMetaElement>("meta[name='robots']");
+    if (!robots) {
+      robots = document.createElement('meta');
+      robots.name = 'robots';
+      document.head.appendChild(robots);
+    }
+    robots.content = 'noindex';
+  }, [copy.metaTitle]);
+
+  return (
+    <div className="flex min-h-screen flex-col bg-[#F4F6FA] text-[var(--text-primary)]">
+      <Header
+        langToggle={{
+          fr: translations.fr.newsletter.meta.canonical,
+          en: translations.en.newsletter.meta.canonical
+        }}
+        forceDarkBackground
+        ctaHref={resolvedLang === 'fr' ? '/fr#hero' : '/#hero'}
+      />
+      <main className="flex flex-1 items-center justify-center px-4 py-24 md:px-6">
+        <div className="w-full max-w-[560px] rounded-[16px] bg-white/95 p-10 shadow-[0_28px_72px_rgba(18,28,45,0.12)] ring-1 ring-black/5">
+          <h1 className="text-3xl font-semibold text-[#121C2D] md:text-4xl">{copy.heading}</h1>
+          <p className="mt-4 text-lg font-semibold text-[#139E9C]">{copy.subheading}</p>
+          <p className="mt-6 text-base leading-relaxed text-[#4B5563]">{copy.intro}</p>
+          <ul className="mt-6 space-y-3 text-base leading-relaxed text-[#4B5563]">
+            {copy.checklist.map(item => (
+              <li key={item} className="flex items-start gap-3">
+                <span className="mt-2 h-2 w-2 rounded-full bg-[#139E9C]" aria-hidden="true" />
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+          <div className="mt-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <a href={copy.ctaHref} className="btn-primary w-full sm:w-auto">
+              {copy.ctaLabel}
+            </a>
+            <p className="text-sm text-[#6B7280] sm:text-right">{copy.support}</p>
+          </div>
+        </div>
+      </main>
+      <Footer
+        langToggle={{
+          fr: translations.fr.newsletter.meta.canonical,
+          en: translations.en.newsletter.meta.canonical
+        }}
+      />
+    </div>
+  );
+};
+
+export default NewsletterConfirmation;

--- a/src/pages/NewsletterPage.tsx
+++ b/src/pages/NewsletterPage.tsx
@@ -65,10 +65,10 @@ const NewsletterPage: React.FC<NewsletterPageProps> = ({ lang }) => {
   }, [lang]);
 
   return (
-    <div className="min-h-screen flex flex-col bg-[#0E1624] text-white">
+    <div className="min-h-screen flex flex-col bg-[var(--off-white)] text-[var(--text-primary)]">
       <Header langToggle={{ fr: CANONICAL.fr, en: CANONICAL.en }} ctaHref={lang === 'fr' ? '/fr#hero' : '/#hero'} />
-      <main className="flex-1 pt-32 pb-24 px-4 md:px-6">
-        <div className="mx-auto">
+      <main className="flex-1 px-4 pb-24 pt-32 md:px-6">
+        <div className="mx-auto flex max-w-7xl justify-center">
           <SignupForm lang={lang} />
         </div>
       </main>

--- a/src/pages/NewsletterPage.tsx
+++ b/src/pages/NewsletterPage.tsx
@@ -71,7 +71,6 @@ const NewsletterPage: React.FC<NewsletterPageProps> = ({ lang }) => {
     <div className="flex min-h-screen flex-col bg-[#F4F6FA] text-[var(--text-primary)]">
       <Header
         langToggle={{ fr: translations.fr.newsletter.meta.canonical, en: translations.en.newsletter.meta.canonical }}
-        ctaHref={lang === 'fr' ? '/fr#hero' : '/#hero'}
         forceDarkBackground
       />
       <main className="flex-1 px-4 pb-24 pt-32 md:px-6">

--- a/src/pages/NewsletterPage.tsx
+++ b/src/pages/NewsletterPage.tsx
@@ -1,0 +1,83 @@
+import React, { useEffect } from 'react';
+import SignupForm from '../components/SignupForm';
+import { Header, Footer } from '../components/Layout';
+import { useLanguage } from '../LanguageProvider';
+
+const TITLES = {
+  fr: 'Infolettre PME Québec | The Automated SMB',
+  en: 'Québec SMB AI Newsletter | The Automated SMB'
+};
+
+const CANONICAL = {
+  fr: '/fr/newsletter',
+  en: '/en/newsletter'
+};
+
+const ensureHeadLink = (selector: string, init: () => HTMLLinkElement) => {
+  let link = document.head.querySelector<HTMLLinkElement>(selector);
+  if (!link) {
+    link = init();
+    document.head.appendChild(link);
+  }
+  return link;
+};
+
+interface NewsletterPageProps {
+  lang: 'fr' | 'en';
+}
+
+const NewsletterPage: React.FC<NewsletterPageProps> = ({ lang }) => {
+  const { setLang } = useLanguage();
+
+  useEffect(() => {
+    setLang(lang);
+  }, [lang, setLang]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof document === 'undefined') return;
+    document.title = TITLES[lang];
+
+    const canonicalHref = `${window.location.origin}${CANONICAL[lang]}`;
+    const alternateHref = `${window.location.origin}${CANONICAL[lang === 'fr' ? 'en' : 'fr']}`;
+
+    const canonical = ensureHeadLink("link[rel='canonical']", () => {
+      const link = document.createElement('link');
+      link.rel = 'canonical';
+      return link;
+    });
+    canonical.href = canonicalHref;
+
+    const frAlt = ensureHeadLink("link[rel='alternate'][hreflang='fr']", () => {
+      const link = document.createElement('link');
+      link.rel = 'alternate';
+      link.hreflang = 'fr';
+      return link;
+    });
+    frAlt.href = lang === 'fr' ? canonicalHref : alternateHref;
+
+    const enAlt = ensureHeadLink("link[rel='alternate'][hreflang='en']", () => {
+      const link = document.createElement('link');
+      link.rel = 'alternate';
+      link.hreflang = 'en';
+      return link;
+    });
+    enAlt.href = lang === 'en' ? canonicalHref : alternateHref;
+  }, [lang]);
+
+  return (
+    <div className="min-h-screen flex flex-col bg-white">
+      <Header langToggle={{ fr: CANONICAL.fr, en: CANONICAL.en }} ctaHref={lang === 'fr' ? '/fr#hero' : '/#hero'} />
+      <main className="flex-1 pt-32 pb-24 px-4">
+        <div className="max-w-3xl mx-auto">
+          <SignupForm lang={lang} />
+        </div>
+      </main>
+      <Footer langToggle={{ fr: CANONICAL.fr, en: CANONICAL.en }} />
+    </div>
+  );
+};
+
+export const NewsletterFR = () => <NewsletterPage lang="fr" />;
+export const NewsletterEN = () => <NewsletterPage lang="en" />;
+
+export default NewsletterPage;

--- a/src/pages/NewsletterPage.tsx
+++ b/src/pages/NewsletterPage.tsx
@@ -8,6 +8,11 @@ const TITLES = {
   en: 'Québec SMB AI Newsletter | The Automated SMB'
 };
 
+const DESCRIPTIONS = {
+  fr: 'Infolettre hebdo pour les PME québécoises : gagnez du temps, réduisez vos coûts et restez conforme à la Loi 25.',
+  en: 'Weekly newsletter for Québec SMBs: save time, cut costs, and stay compliant with Law 25.'
+};
+
 const CANONICAL = {
   fr: '/fr/newsletter',
   en: '/en/newsletter'
@@ -40,6 +45,14 @@ const NewsletterPage: React.FC<NewsletterPageProps> = ({ lang }) => {
     const canonicalHref = `${window.location.origin}${CANONICAL[lang]}`;
     const alternateHref = `${window.location.origin}${CANONICAL[lang === 'fr' ? 'en' : 'fr']}`;
 
+    let metaDescription = document.head.querySelector<HTMLMetaElement>("meta[name='description']");
+    if (!metaDescription) {
+      metaDescription = document.createElement('meta');
+      metaDescription.name = 'description';
+      document.head.appendChild(metaDescription);
+    }
+    metaDescription.content = DESCRIPTIONS[lang];
+
     const canonical = ensureHeadLink("link[rel='canonical']", () => {
       const link = document.createElement('link');
       link.rel = 'canonical';
@@ -66,7 +79,11 @@ const NewsletterPage: React.FC<NewsletterPageProps> = ({ lang }) => {
 
   return (
     <div className="min-h-screen flex flex-col bg-[var(--off-white)] text-[var(--text-primary)]">
-      <Header langToggle={{ fr: CANONICAL.fr, en: CANONICAL.en }} ctaHref={lang === 'fr' ? '/fr#hero' : '/#hero'} />
+      <Header
+        langToggle={{ fr: CANONICAL.fr, en: CANONICAL.en }}
+        ctaHref={lang === 'fr' ? '/fr#hero' : '/#hero'}
+        forceDarkBackground
+      />
       <main className="flex-1 px-4 pb-24 pt-32 md:px-6">
         <div className="mx-auto flex max-w-7xl justify-center">
           <SignupForm lang={lang} />

--- a/src/pages/NewsletterPage.tsx
+++ b/src/pages/NewsletterPage.tsx
@@ -65,10 +65,10 @@ const NewsletterPage: React.FC<NewsletterPageProps> = ({ lang }) => {
   }, [lang]);
 
   return (
-    <div className="min-h-screen flex flex-col bg-white">
+    <div className="min-h-screen flex flex-col bg-[#0E1624] text-white">
       <Header langToggle={{ fr: CANONICAL.fr, en: CANONICAL.en }} ctaHref={lang === 'fr' ? '/fr#hero' : '/#hero'} />
-      <main className="flex-1 pt-32 pb-24 px-4">
-        <div className="max-w-3xl mx-auto">
+      <main className="flex-1 pt-32 pb-24 px-4 md:px-6">
+        <div className="mx-auto">
           <SignupForm lang={lang} />
         </div>
       </main>

--- a/src/pages/NewsletterPage.tsx
+++ b/src/pages/NewsletterPage.tsx
@@ -2,21 +2,7 @@ import React, { useEffect } from 'react';
 import SignupForm from '../components/SignupForm';
 import { Header, Footer } from '../components/Layout';
 import { useLanguage } from '../LanguageProvider';
-
-const TITLES = {
-  fr: 'Infolettre PME Québec | The Automated SMB',
-  en: 'Québec SMB AI Newsletter | The Automated SMB'
-};
-
-const DESCRIPTIONS = {
-  fr: 'Infolettre hebdo pour les PME québécoises : gagnez du temps, réduisez vos coûts et restez conforme à la Loi 25.',
-  en: 'Weekly newsletter for Québec SMBs: save time, cut costs, and stay compliant with Law 25.'
-};
-
-const CANONICAL = {
-  fr: '/fr/newsletter',
-  en: '/en/newsletter'
-};
+import { translations, type Language } from '../i18n';
 
 const ensureHeadLink = (selector: string, init: () => HTMLLinkElement) => {
   let link = document.head.querySelector<HTMLLinkElement>(selector);
@@ -28,11 +14,12 @@ const ensureHeadLink = (selector: string, init: () => HTMLLinkElement) => {
 };
 
 interface NewsletterPageProps {
-  lang: 'fr' | 'en';
+  lang: Extract<Language, 'fr' | 'en'>;
 }
 
 const NewsletterPage: React.FC<NewsletterPageProps> = ({ lang }) => {
   const { setLang } = useLanguage();
+  const copy = translations[lang].newsletter;
 
   useEffect(() => {
     setLang(lang);
@@ -40,10 +27,9 @@ const NewsletterPage: React.FC<NewsletterPageProps> = ({ lang }) => {
 
   useEffect(() => {
     if (typeof window === 'undefined' || typeof document === 'undefined') return;
-    document.title = TITLES[lang];
 
-    const canonicalHref = `${window.location.origin}${CANONICAL[lang]}`;
-    const alternateHref = `${window.location.origin}${CANONICAL[lang === 'fr' ? 'en' : 'fr']}`;
+    localStorage.setItem('newsletter_lang', lang);
+    document.title = copy.meta.title;
 
     let metaDescription = document.head.querySelector<HTMLMetaElement>("meta[name='description']");
     if (!metaDescription) {
@@ -51,7 +37,11 @@ const NewsletterPage: React.FC<NewsletterPageProps> = ({ lang }) => {
       metaDescription.name = 'description';
       document.head.appendChild(metaDescription);
     }
-    metaDescription.content = DESCRIPTIONS[lang];
+    metaDescription.content = copy.meta.description;
+
+    const frHref = `${window.location.origin}${translations.fr.newsletter.meta.canonical}`;
+    const enHref = `${window.location.origin}${translations.en.newsletter.meta.canonical}`;
+    const canonicalHref = lang === 'fr' ? frHref : enHref;
 
     const canonical = ensureHeadLink("link[rel='canonical']", () => {
       const link = document.createElement('link');
@@ -66,7 +56,7 @@ const NewsletterPage: React.FC<NewsletterPageProps> = ({ lang }) => {
       link.hreflang = 'fr';
       return link;
     });
-    frAlt.href = lang === 'fr' ? canonicalHref : alternateHref;
+    frAlt.href = frHref;
 
     const enAlt = ensureHeadLink("link[rel='alternate'][hreflang='en']", () => {
       const link = document.createElement('link');
@@ -74,13 +64,13 @@ const NewsletterPage: React.FC<NewsletterPageProps> = ({ lang }) => {
       link.hreflang = 'en';
       return link;
     });
-    enAlt.href = lang === 'en' ? canonicalHref : alternateHref;
-  }, [lang]);
+    enAlt.href = enHref;
+  }, [lang, copy.meta.description, copy.meta.title]);
 
   return (
-    <div className="min-h-screen flex flex-col bg-[#F4F6FA] text-[var(--text-primary)]">
+    <div className="flex min-h-screen flex-col bg-[#F4F6FA] text-[var(--text-primary)]">
       <Header
-        langToggle={{ fr: CANONICAL.fr, en: CANONICAL.en }}
+        langToggle={{ fr: translations.fr.newsletter.meta.canonical, en: translations.en.newsletter.meta.canonical }}
         ctaHref={lang === 'fr' ? '/fr#hero' : '/#hero'}
         forceDarkBackground
       />
@@ -89,7 +79,7 @@ const NewsletterPage: React.FC<NewsletterPageProps> = ({ lang }) => {
           <SignupForm lang={lang} />
         </div>
       </main>
-      <Footer langToggle={{ fr: CANONICAL.fr, en: CANONICAL.en }} />
+      <Footer langToggle={{ fr: translations.fr.newsletter.meta.canonical, en: translations.en.newsletter.meta.canonical }} />
     </div>
   );
 };

--- a/src/pages/NewsletterPage.tsx
+++ b/src/pages/NewsletterPage.tsx
@@ -78,7 +78,7 @@ const NewsletterPage: React.FC<NewsletterPageProps> = ({ lang }) => {
   }, [lang]);
 
   return (
-    <div className="min-h-screen flex flex-col bg-[var(--off-white)] text-[var(--text-primary)]">
+    <div className="min-h-screen flex flex-col bg-[#F4F6FA] text-[var(--text-primary)]">
       <Header
         langToggle={{ fr: CANONICAL.fr, en: CANONICAL.en }}
         ctaHref={lang === 'fr' ? '/fr#hero' : '/#hero'}


### PR DESCRIPTION
## Summary
- add a reusable SignupForm component that posts to the Brevo endpoint with required fields and bilingual copy
- create dedicated English and French newsletter routes that reuse the site chrome and manage SEO metadata
- ensure supporting assets like Brevo styles, reCAPTCHA loader, and hidden spam-trap styling are loaded globally

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc332176708323ae0f6f7cb2b1110d