### PR TITLE
Redesign hero and navbar to drive Diagnostic Éclair bookings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,20 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useLanguage } from './LanguageProvider';
 import {
-  MessageSquare, CalendarX, Receipt, Shield, CheckCircle,
-  Zap, CalendarCheck, Star,
-  ChevronDown, ChevronUp
+  MessageSquare,
+  CalendarX,
+  Receipt,
+  Shield,
+  CheckCircle,
+  Zap,
+  CalendarCheck,
+  Star,
+  ChevronDown,
+  ChevronUp,
+  Sparkles,
+  CheckCircle2,
+  ShieldCheck,
+  Clock3
 } from 'lucide-react';
 import { Header, Footer } from './components/Layout';
 import PartnerBar from './components/PartnerBar';
@@ -11,48 +22,96 @@ import PartnerBar from './components/PartnerBar';
 // Hero Component
 const Hero = () => {
   const { t } = useLanguage();
-  const isFR = typeof window !== 'undefined' && window.location.pathname.startsWith('/fr');
-  const newsletterHref = isFR ? '/fr/newsletter' : '/en/newsletter';
+  const hero = t.hero;
 
   return (
-    <section
-      id="hero"
-      className="relative min-h-screen flex items-center justify-center overflow-hidden"
-      style={{ background: '#121C2D' }}
-    >
-      {/* Animated background elements */}
-      <div className="absolute inset-0">
-        <div className="absolute top-20 left-10 w-72 h-72 bg-blue-500/10 rounded-full blur-3xl animate-float" />
-        <div
-          className="absolute bottom-20 right-10 w-96 h-96 bg-teal-400/10 rounded-full blur-3xl animate-float"
-          style={{ animationDelay: '2s' }}
-        />
+    <section id="hero" className="relative isolate overflow-hidden bg-[#0B1320] text-white">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute -top-32 -left-24 h-72 w-72 rounded-full bg-[#2280FF]/20 blur-3xl" />
+        <div className="absolute bottom-[-6rem] right-[-4rem] h-[26rem] w-[26rem] rounded-full bg-[#139E9C]/20 blur-3xl" />
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(19,158,156,0.08),transparent_60%)]" />
       </div>
 
-      <div className="relative z-10 max-w-6xl mx-auto px-6 lg:px-8 text-center">
-        <div className="inline-flex items-center card-glass rounded-full px-4 py-2 mb-8">
-          <span className="text-sm font-medium text-white">{t.hero.eyebrow}</span>
+      <div className="relative z-10 mx-auto flex min-h-screen max-w-7xl flex-col justify-center px-6 pb-16 pt-28 lg:px-8 lg:pb-24">
+        <div className="grid items-center gap-14 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)] xl:gap-20">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-white/60">
+              {hero.trustTag}
+            </p>
+
+            <h1 className="mt-6 text-4xl font-semibold leading-tight sm:text-5xl lg:text-[3.4rem] lg:leading-[1.05]">
+              <span className="block">{hero.headline.leading}</span>
+              <span className="block text-[#139E9C]">{hero.headline.accent}</span>
+              <span className="block">{hero.headline.trailing}</span>
+            </h1>
+
+            <p className="mt-6 max-w-xl text-lg text-white/80 lg:text-xl">{hero.subheadline}</p>
+
+            <div className="mt-8 flex flex-col gap-4 sm:flex-row sm:items-center">
+              <a
+                href={hero.primaryHref}
+                className="inline-flex items-center justify-center rounded-full bg-[#139E9C] px-7 py-3 text-base font-semibold text-[#041820] shadow-lg shadow-[#139E9C]/40 transition-transform duration-200 hover:-translate-y-0.5 hover:shadow-[#139E9C]/60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#139E9C]"
+              >
+                {hero.primaryCta}
+              </a>
+              <a
+                href={hero.secondaryHref}
+                className="text-sm font-medium text-white/70 underline decoration-white/30 underline-offset-4 transition-colors hover:text-white"
+              >
+                {hero.secondaryCta}
+              </a>
+            </div>
+
+            <p className="mt-6 text-sm text-white/60">{hero.assurance}</p>
+
+            <div className="mt-12 space-y-4">
+              <p className="text-xs font-semibold uppercase tracking-[0.25em] text-white/40">
+                {hero.trustLogosLabel}
+              </p>
+              <div className="flex flex-wrap items-center gap-x-8 gap-y-3 text-sm font-semibold uppercase tracking-wide text-white/50">
+                {hero.trustLogos.map((logo: string) => (
+                  <span key={logo} className="flex items-center gap-2">
+                    <span className="h-1.5 w-1.5 rounded-full bg-[#139E9C]" />
+                    {logo}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <div className="relative">
+            <div className="absolute -top-6 -right-6 hidden h-24 w-24 rounded-full bg-[#2280FF]/20 blur-3xl lg:block" />
+            <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-8 backdrop-blur-xl lg:p-10">
+              <div className="absolute inset-0 bg-gradient-to-br from-white/10 via-transparent to-[#139E9C]/10" />
+              <div className="relative">
+                <div className="flex items-center gap-3 text-[#139E9C]">
+                  <Sparkles className="h-5 w-5" />
+                  <p className="text-xs font-semibold uppercase tracking-[0.3em] text-[#139E9C]">
+                    {hero.checklistTitle}
+                  </p>
+                </div>
+                <ul className="mt-6 space-y-4">
+                  {hero.checklist.map((item: string) => (
+                    <li key={item} className="flex items-start gap-3 text-base leading-relaxed text-white/90">
+                      <CheckCircle2 className="mt-1 h-5 w-5 flex-shrink-0 text-[#139E9C]" />
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                </ul>
+                <div className="mt-8 space-y-3 text-sm text-white/70">
+                  <div className="flex items-center gap-3">
+                    <ShieldCheck className="h-5 w-5 text-[#139E9C]" />
+                    <span>{hero.complianceNote}</span>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <Clock3 className="h-5 w-5 text-[#139E9C]" />
+                    <span>{hero.installTime}</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
-
-        <h1 className="text-hero text-white mb-6 leading-tight tracking-tight">
-          <span>{t.hero.h1_part1} </span>
-          <span className="accent">{t.hero.h1_accent}</span>
-        </h1>
-
-        <p className="text-subhead !text-white/90 max-w-3xl mx-auto mb-4">{t.hero.subhead}</p>
-        <p className="text-sm !text-white/70 mb-10">{t.hero.proof}</p>
-
-        <div className="flex justify-center">
-          <a
-            href={newsletterHref}
-            className="btn-primary text-lg px-8 py-4"
-            data-event="cta_click"
-            data-cta="newsletter"
-          >
-            {t.hero.primaryCta}
-          </a>
-        </div>
-
       </div>
     </section>
   );

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -35,61 +35,96 @@ export const Header: React.FC<{
   const resolvedCtaHref = ctaHref ?? newsletterHref;
   const resolvedCtaLabel = ctaLabel ?? t.header.cta;
 
-  const LanguageToggle = ({ className }: { className?: string }) => {
-    const otherLang = lang === 'fr' ? 'en' : 'fr';
-    const target = lang === 'fr' ? langToggle?.en ?? '/' : langToggle?.fr ?? '/fr';
-    const color = className ?? textClass;
+  const LanguageToggle = ({ tone = 'desktop' }: { tone?: 'desktop' | 'mobile' }) => {
+    const goTo = (targetLang: 'fr' | 'en') => {
+      if (lang === targetLang) return;
+      setLang(targetLang);
+      localStorage.setItem('lang', targetLang);
+      const href = targetLang === 'fr' ? langToggle?.fr ?? '/fr' : langToggle?.en ?? '/';
+      window.location.href = href;
+    };
+
+    const isLight = textClass.includes('#121C2D');
+    const isMobile = tone === 'mobile';
+    const activeClass = isMobile
+      ? 'text-white'
+      : isLight
+      ? 'text-[#121C2D]'
+      : 'text-white';
+    const inactiveClass = isMobile
+      ? 'text-white/60 hover:text-white'
+      : isLight
+      ? 'text-[#121C2D]/60 hover:text-[#121C2D]'
+      : 'text-white/60 hover:text-white';
+    const dividerClass = isMobile
+      ? 'text-white/25'
+      : isLight
+      ? 'text-[#121C2D]/30'
+      : 'text-white/30';
+
+    const wrapperClass =
+      tone === 'desktop'
+        ? 'flex items-center text-[0.7rem] font-semibold uppercase tracking-[0.35em]'
+        : 'flex items-center text-[0.7rem] font-semibold uppercase tracking-[0.35em]';
+
     return (
-      <button
-        aria-label="Switch language"
-        onClick={() => {
-          setLang(otherLang as 'fr' | 'en');
-          localStorage.setItem('lang', otherLang);
-          window.location.href = target;
-        }}
-        className={`px-3 py-1 rounded-full border ${color} border-current hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#2280FF]`}
-      >
-        {otherLang.toUpperCase()}
-      </button>
+      <div className={wrapperClass}>
+        <button
+          type="button"
+          aria-pressed={lang === 'fr'}
+          onClick={() => goTo('fr')}
+          className={`${lang === 'fr' ? activeClass : inactiveClass} transition-colors`}
+        >
+          FR
+        </button>
+        <span className={`mx-2 ${dividerClass}`}>|</span>
+        <button
+          type="button"
+          aria-pressed={lang === 'en'}
+          onClick={() => goTo('en')}
+          className={`${lang === 'en' ? activeClass : inactiveClass} transition-colors`}
+        >
+          EN
+        </button>
+      </div>
     );
   };
 
   const headerBackgroundClass = forceDarkBackground
-    ? 'bg-[#121C2D]'
+    ? 'bg-[#0B1320]/95 backdrop-blur-lg border-b border-white/10'
     : isScrolled
-    ? 'bg-[#121C2D]'
+    ? 'bg-[#0B1320]/90 backdrop-blur-lg border-b border-white/10'
     : 'bg-transparent';
 
   return (
     <>
-      <header
-        className={`fixed top-0 left-0 right-0 z-50 transition-colors duration-500 ${headerBackgroundClass}`}
-      >
-        <div className="max-w-7xl mx-auto px-6 lg:px-8">
-          <div className="flex justify-between items-center py-4">
+      <header className={`fixed top-0 left-0 right-0 z-50 transition-all duration-500 ${headerBackgroundClass}`}>
+        <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-4 lg:px-8">
+          <a
+            href={lang === 'fr' ? '/fr' : '/'}
+            onClick={() => localStorage.setItem('lang', lang)}
+            className={`text-xl font-semibold tracking-tight ${resolvedTextClass}`}
+          >
+            {t.header.brand}
+          </a>
+          <div className="hidden items-center gap-8 md:flex">
+            <LanguageToggle />
             <a
-              href={lang === 'fr' ? '/fr' : '/'}
-              onClick={() => localStorage.setItem('lang', lang)}
-              className={`text-2xl font-bold ${resolvedTextClass}`}
+              href={resolvedCtaHref}
+              className="inline-flex items-center justify-center rounded-full bg-[#139E9C] px-5 py-2 text-sm font-semibold text-[#041820] shadow-sm shadow-[#139E9C]/40 transition-transform duration-150 hover:-translate-y-0.5 hover:shadow-[#139E9C]/60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#139E9C]"
             >
-              {t.header.brand}
+              {resolvedCtaLabel}
             </a>
-            <div className="hidden md:flex items-center space-x-8">
-              <LanguageToggle />
-              <a href={resolvedCtaHref} className="btn-primary text-sm px-6 py-3">
-                {resolvedCtaLabel}
-              </a>
-            </div>
-            <div className="flex md:hidden items-center space-x-4">
-              <LanguageToggle />
-              <button onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}>
-                {isMobileMenuOpen ? (
-                  <X className={`w-6 h-6 ${resolvedTextClass}`} />
-                ) : (
-                  <Menu className={`w-6 h-6 ${resolvedTextClass}`} />
-                )}
-              </button>
-            </div>
+          </div>
+          <div className="flex items-center gap-4 md:hidden">
+            <LanguageToggle />
+            <button onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}>
+              {isMobileMenuOpen ? (
+                <X className={`w-6 h-6 ${resolvedTextClass}`} />
+              ) : (
+                <Menu className={`w-6 h-6 ${resolvedTextClass}`} />
+              )}
+            </button>
           </div>
         </div>
       </header>
@@ -105,13 +140,16 @@ export const Header: React.FC<{
           onClick={() => setIsMobileMenuOpen(false)}
         />
         <div
-          className={`absolute top-0 right-0 h-full w-64 bg-white shadow-2xl transform transition-transform duration-300 ${
+          className={`absolute top-0 right-0 h-full w-72 bg-[#0B1320] text-white shadow-2xl transition-transform duration-300 ${
             isMobileMenuOpen ? 'translate-x-0' : 'translate-x-full'
           }`}
         >
-          <div className="p-6 pt-20 space-y-6 text-center">
-            <LanguageToggle className="text-[#121C2D]" />
-            <a href={resolvedCtaHref} className="btn-primary w-full">
+          <div className="flex h-full flex-col gap-8 p-6 pt-24">
+            <LanguageToggle tone="mobile" />
+            <a
+              href={resolvedCtaHref}
+              className="inline-flex items-center justify-center rounded-full bg-[#139E9C] px-6 py-3 text-sm font-semibold text-[#041820] shadow-sm shadow-[#139E9C]/40 transition-transform duration-150 hover:-translate-y-0.5 hover:shadow-[#139E9C]/60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#139E9C]"
+            >
               {resolvedCtaLabel}
             </a>
           </div>

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -5,17 +5,32 @@ export const en = {
     brand: 'Simon Paris',
     languageToggle: 'EN/FR',
     email: 'info@simonparis.ca',
-    cta: 'Join Newsletter'
+    cta: 'Diagnostic Éclair'
   },
   hero: {
-    eyebrow: 'For Québec clinics • Law 25 + Bill 96 ready',
-    h1_part1: 'Fill Your Schedule.',
-    h1_accent: 'Stay 100% Compliant.',
-    subhead:
-      'Plug‑and‑play bilingual automations for Speed‑to‑Lead, No‑Show Chaser, and Review Engine—built for Québec clinics. Demo first. Install in minutes.',
-    proof:
-      'Clinics that automate often see 25–50% fewer no‑shows and much faster follow‑ups.',
-    primaryCta: 'Join Newsletter'
+    trustTag: 'For Québec clinics • Law 25 ready • Plain language',
+    headline: {
+      leading: 'Fewer no-shows.',
+      accent: 'More booked patients.',
+      trailing: '100% compliant.'
+    },
+    subheadline:
+      'In 20 minutes, we surface a leak in your follow-ups, missed calls, or reminders—and leave you with a simple action plan.',
+    primaryCta: 'Book a Diagnostic Éclair',
+    primaryHref: 'https://cal.com/simonparis/diagnostic',
+    secondaryCta: 'Not ready? Join the briefing.',
+    secondaryHref: '/en/newsletter',
+    assurance: 'Choose the conversation in French or English—whatever serves your team.',
+    checklistTitle: 'During the call we pinpoint:',
+    checklist: [
+      'One bottleneck that’s draining time or patients each week',
+      'An automation you can deploy without replacing your PMS/EMR',
+      'The next step to stay calm about Law 25 / Bill 96'
+    ],
+    complianceNote: 'Includes a quick Law 25 & Bill 96 compliance check.',
+    installTime: 'Typical setup: 5–10 business days.',
+    trustLogosLabel: 'Plays nicely with your stack',
+    trustLogos: ['Stripe', 'Airtable', 'Microsoft Founders Hub']
   },
   problems: {
     title: 'Why clinics <span class="accent">lose money</span> every week…',

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -6,16 +6,32 @@ const fr: TranslationKeys = {
     brand: 'Simon Paris',
     languageToggle: 'FR/EN',
     email: 'info@simonparis.ca',
-    cta: 'Joindre l’infolettre'
+    cta: 'Diagnostic Éclair'
   },
   hero: {
-    eyebrow: 'Pour les cliniques du Québec • Prêt Loi 25 + Loi 96',
-    h1_part1: 'Remplissez votre horaire.',
-    h1_accent: 'Restez 100% conforme.',
-    subhead:
-      'Automatisations bilingues prêtes à l’emploi pour vitesse‑à‑lead, relance d’absences et moteur d’avis — conçues pour les cliniques du Québec. Démo d’abord. Installation en minutes.',
-    proof: 'Les cliniques qui automatisent voient souvent 25–50 % moins d’absences et des suivis beaucoup plus rapides.',
-    primaryCta: 'Joindre l’infolettre'
+    trustTag: 'Pour les cliniques du Québec • Loi 25 prête • Zéro jargon',
+    headline: {
+      leading: 'Moins de no-shows.',
+      accent: 'Plus de patients.',
+      trailing: '100 % conforme.'
+    },
+    subheadline:
+      'En 20 min, on repère une fuite de temps ou de revenus dans vos suivis, appels ou rappels — et vous repartez avec un plan clair.',
+    primaryCta: 'Réserver un Diagnostic Éclair',
+    primaryHref: 'https://cal.com/simonparis/diagnostic',
+    secondaryCta: 'Pas prêt? Recevoir l’infolettre.',
+    secondaryHref: '/fr/newsletter',
+    assurance: 'La rencontre est offerte en français ou en anglais, selon votre équipe.',
+    checklistTitle: 'Pendant l’appel, on identifie :',
+    checklist: [
+      'Un goulot qui vous fait perdre des patients ou des heures chaque semaine',
+      'Une tâche à automatiser sans changer votre logiciel clinique',
+      'La prochaine étape pour rester tranquille côté Loi 25 / Loi 96'
+    ],
+    complianceNote: 'Inclut une vérification express Loi 25 et Loi 96.',
+    installTime: 'Installation typique : 5 à 10 jours ouvrables.',
+    trustLogosLabel: 'S’intègre à vos outils existants',
+    trustLogos: ['Stripe', 'Airtable', 'Microsoft Founders Hub']
   },
   problems: {
     title: 'Pourquoi les cliniques <span class="accent">perdent de l’argent</span> chaque semaine…',


### PR DESCRIPTION
## Summary
- rebuild the hero section with localized trust tag, compliance messaging, and Diagnostic Éclair call-to-actions
- refresh the navigation bar with a clearer FR/EN toggle and accent CTA button to book the diagnostic
- update FR and EN translations to support the new hero copy and navigation labels

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e076ec06cc8323a53ba36df25e611f