### PR TITLE
Streamline newsletter CTA banner and compact footer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import {
 } from 'lucide-react';
 import { Header, Footer } from './components/Layout';
 import PartnerBar from './components/PartnerBar';
+import FinalCTA from './components/FinalCTA';
 
 // Hero Component
 const Hero = () => {
@@ -463,31 +464,6 @@ const FAQ = () => {
               </div>
             </div>
           ))}
-        </div>
-      </div>
-    </section>
-  );
-};
-
-// Final CTA Component
-const FinalCTA = () => {
-  const { t, lang } = useLanguage();
-  const base = lang === 'fr' ? '/fr' : '';
-  const resolveHref = (path: string) =>
-    path.startsWith('/fr') || path.startsWith('/en') ? path : `${base}${path}`;
-
-  return (
-    <section className="relative py-16 bg-[#121C2D] text-center text-white">
-      <div className="max-w-4xl mx-auto px-6">
-        <h2 className="text-3xl font-bold mb-4">{t.finalCTA.title}</h2>
-        <p className="text-lg text-white/80 mb-8">{t.finalCTA.sub}</p>
-        <div className="flex flex-col sm:flex-row gap-4 justify-center">
-          <a href={resolveHref(t.finalCTA.primaryHref)} className="btn-primary px-8 py-4">
-            {t.finalCTA.primary}
-          </a>
-          <a href={resolveHref(t.finalCTA.secondaryHref)} className="btn-outline text-lg px-8 py-4">
-            {t.finalCTA.secondary}
-          </a>
         </div>
       </div>
     </section>

--- a/src/components/FinalCTA.tsx
+++ b/src/components/FinalCTA.tsx
@@ -1,175 +1,32 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { Send, Calendar, ArrowRight, Sparkles } from 'lucide-react';
+import React from 'react';
+import { useLanguage } from '../LanguageProvider';
 
-const FinalCTA = () => {
-  const [formData, setFormData] = useState({
-    name: '',
-    email: '',
-    businessType: '',
-    painPoint: ''
-  });
-  const [isVisible, setIsVisible] = useState(false);
-  const sectionRef = useRef<HTMLElement>(null);
-
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          setIsVisible(true);
-        }
-      },
-      { threshold: 0.3 }
-    );
-
-    if (sectionRef.current) {
-      observer.observe(sectionRef.current);
-    }
-
-    return () => observer.disconnect();
-  }, []);
-
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
-    setFormData({
-      ...formData,
-      [e.target.name]: e.target.value
-    });
-  };
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    console.log('Form submitted:', formData);
-  };
+const FinalCTA: React.FC = () => {
+  const { t, lang } = useLanguage();
+  const fallbackHref = lang === 'fr' ? '/fr/newsletter' : '/en/newsletter';
+  const ctaHref = t.finalcta?.href ?? fallbackHref;
 
   return (
-    <>
-      <section ref={sectionRef} className="relative py-20 overflow-hidden" style={{ background: '#121C2D' }}>
-        {/* Animated background elements */}
-        <div className="absolute inset-0">
-          <div className="absolute top-20 left-10 w-72 h-72 bg-teal-400/5 rounded-full blur-3xl animate-float" />
-          <div className="absolute bottom-20 right-10 w-96 h-96 bg-blue-500/5 rounded-full blur-3xl animate-float" style={{ animationDelay: '2s' }} />
+    <section className="bg-[#0B1220] py-12 md:py-14 text-white">
+      <div className="mx-auto flex max-w-5xl flex-col gap-6 px-6 md:flex-row md:items-center md:justify-between">
+        <div className="space-y-3 text-center md:text-left md:max-w-3xl">
+          <h2 className="text-2xl font-semibold leading-tight md:text-3xl">
+            {t.finalcta.headline}
+          </h2>
+          <p className="text-base text-white/70">
+            {t.finalcta.subtext}
+          </p>
         </div>
-
-        <div className="relative z-10 max-w-4xl mx-auto px-6 lg:px-8">
-          <div className={`text-center mb-12 transition-all duration-1000 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}>
-            <div className="inline-flex items-center card-glass rounded-full px-4 py-2 mb-6">
-              <Sparkles className="w-4 h-4 mr-2" style={{ color: '#2280FF' }} />
-              <span className="text-sm font-medium text-white">Ready to Transform Your Business?</span>
-            </div>
-            <h2 className="text-display text-white mb-6">
-              Ready to Stop Losing Business and 
-              <span className="text-teal-400"> Sleep Easy on Compliance</span>?
-            </h2>
-            <p className="text-subhead text-gray-300">
-              Get your free workflow audit and see exactly where you're losing money
-            </p>
-          </div>
-          
-          <div className={`transition-all duration-1000 delay-300 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}>
-            <div className="card-dark p-8 lg:p-12 backdrop-blur-xl">
-              <form onSubmit={handleSubmit} className="space-y-6">
-                <div className="grid md:grid-cols-2 gap-6">
-                  <div>
-                    <label htmlFor="name" className="block text-sm font-semibold text-white mb-3">
-                      Name *
-                    </label>
-                    <input
-                      type="text"
-                      id="name"
-                      name="name"
-                      required
-                      value={formData.name}
-                      onChange={handleInputChange}
-                      className="w-full px-6 py-4 bg-white border-2 border-gray-200 rounded-2xl focus:ring-4 focus:ring-teal-400/20 focus:border-teal-400 transition-all duration-300 text-lg text-gray-900"
-                      placeholder="Your full name"
-                    />
-                  </div>
-                  
-                  <div>
-                    <label htmlFor="email" className="block text-sm font-semibold text-white mb-3">
-                      Email *
-                    </label>
-                    <input
-                      type="email"
-                      id="email"
-                      name="email"
-                      required
-                      value={formData.email}
-                      onChange={handleInputChange}
-                      className="w-full px-6 py-4 bg-white border-2 border-gray-200 rounded-2xl focus:ring-4 focus:ring-[#2280FF]/20 focus:border-[#2280FF] transition-all duration-300 text-lg text-gray-900"
-                      placeholder="your@email.com"
-                    />
-                  </div>
-                </div>
-                
-                <div>
-                  <label htmlFor="businessType" className="block text-sm font-semibold text-white mb-3">
-                    Business Type *
-                  </label>
-                  <select
-                    id="businessType"
-                    name="businessType"
-                    required
-                    value={formData.businessType}
-                    onChange={handleInputChange}
-                    className="w-full px-6 py-4 bg-white border-2 border-gray-200 rounded-2xl focus:ring-4 focus:ring-[#2280FF]/20 focus:border-[#2280FF] transition-all duration-300 text-lg text-gray-900"
-                  >
-                    <option value="">Select your business type</option>
-                    <option value="clinic">Medical/Dental Clinic</option>
-                    <option value="wellness">Wellness/Spa Business</option>
-                    <option value="trades">Trades/Contractor</option>
-                    <option value="other">Other Service Business</option>
-                  </select>
-                </div>
-                
-                <div>
-                  <label htmlFor="painPoint" className="block text-sm font-semibold text-white mb-3">
-                    Your Biggest Pain Point
-                  </label>
-                  <textarea
-                    id="painPoint"
-                    name="painPoint"
-                    rows={4}
-                    value={formData.painPoint}
-                    onChange={handleInputChange}
-                    className="w-full px-6 py-4 bg-white border-2 border-gray-200 rounded-2xl focus:ring-4 focus:ring-[#2280FF]/20 focus:border-[#2280FF] transition-all duration-300 text-lg resize-none text-gray-900"
-                    placeholder="What's your biggest challenge with follow-ups, no-shows, or reviews?"
-                  />
-                </div>
-                
-                <div className="pt-4">
-                  <button
-                    type="submit"
-                    className="w-full btn-primary text-xl py-6 group"
-                  >
-                    <Calendar className="w-6 h-6 mr-3" />
-                    Book Your Free 15-Minute Demo
-                    <ArrowRight className="w-6 h-6 ml-3 group-hover:translate-x-1 transition-transform" />
-                  </button>
-                </div>
-              </form>
-              
-              <div className="mt-8 pt-8 border-t border-gray-600 text-center">
-                <p className="text-gray-300 mb-4 text-lg">Or, send a quick question to:</p>
-                <a
-                  href="mailto:info@simonparis.ca"
-                  className="inline-flex items-center font-semibold text-lg group transition-colors duration-300 text-[#2280FF]"
-                >
-                  <Send className="w-5 h-5 mr-2 group-hover:translate-x-1 transition-transform" />
-                  info@simonparis.ca
-                </a>
-              </div>
-            </div>
-          </div>
+        <div className="flex flex-col items-center gap-3 md:items-end">
+          <a
+            href={ctaHref}
+            className="bg-[#139E9C] text-white hover:bg-[#118C89] px-6 py-3 rounded-xl font-semibold shadow-md hover:shadow-lg transition focus:outline-none focus:ring-2 focus:ring-[#139E9C]/40"
+          >
+            {t.finalcta.cta}
+          </a>
         </div>
-      </section>
-
-      {/* Sticky CTA for mobile */}
-      <div className="sticky-cta md:hidden">
-        <button className="btn-primary w-full text-lg py-4">
-          Book Free Demo
-        </button>
       </div>
-    </>
+    </section>
   );
 };
 

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useLanguage } from '../LanguageProvider';
-import { Menu, X, Mail, MapPin } from 'lucide-react';
+import { Menu, X } from 'lucide-react';
 
 export const Header: React.FC<{
   langToggle?: { fr: string; en: string };
@@ -122,78 +122,36 @@ export const Header: React.FC<{
 };
 
 export const Footer: React.FC<{ langToggle?: { fr: string; en: string } }> = ({
-  langToggle
+  langToggle: _langToggle
 }) => {
-  const { t, lang, setLang } = useLanguage();
-
-  const LanguageToggle = () => {
-    const otherLang = lang === 'fr' ? 'en' : 'fr';
-    const target = lang === 'fr' ? langToggle?.en ?? '/' : langToggle?.fr ?? '/fr';
-    return (
-      <button
-        aria-label="Switch language"
-        onClick={() => {
-          setLang(otherLang as 'fr' | 'en');
-          localStorage.setItem('lang', otherLang);
-          window.location.href = target;
-        }}
-        className="px-3 py-1 rounded-full border border-white text-white hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#2280FF]"
-      >
-        {otherLang.toUpperCase()}
-      </button>
-    );
-  };
+  const { t } = useLanguage();
 
   return (
-    <footer className="relative py-16 bg-[#121C2D] text-white">
-      <div className="max-w-7xl mx-auto px-6 lg:px-8">
-        <div className="grid md:grid-cols-3 gap-8 mb-12">
-          <div>
-            <div className="text-2xl font-bold mb-4">{t.header.brand}</div>
-            <p className="mb-6 leading-relaxed">{t.footer.blurb}</p>
-            <LanguageToggle />
+    <footer className="bg-[#0B1220] text-white">
+      <div className="mx-auto max-w-7xl px-6 py-6 md:py-8 lg:px-8">
+        <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+          <div className="text-center md:text-left">
+            <div className="text-xl font-semibold md:text-2xl">{t.header.brand}</div>
+            <p className="mt-1 text-sm text-white/70 md:text-base">{t.footer.tagline}</p>
           </div>
 
-          <div>
-            <h4 className="text-lg font-semibold mb-4">{t.footer.services}</h4>
-            <ul className="space-y-2">
-              {t.footer.servicesList.map(item => (
-                <li key={item}>{item}</li>
-              ))}
-            </ul>
-          </div>
+          <div className="hidden flex-1 md:block" aria-hidden="true" />
 
-          <div>
-            <h4 className="text-lg font-semibold mb-4">{t.footer.contact}</h4>
-            <div className="space-y-3">
-              <a
-                href={`mailto:${t.header.email}`}
-                className="flex items-center hover:text-[#2280FF] transition-colors"
-              >
-                <Mail className="w-4 h-4 mr-2" />
-                {t.header.email}
-              </a>
-              <div className="flex items-center">
-                <MapPin className="w-4 h-4 mr-2" />
-                {t.footer.location}
-              </div>
-            </div>
-          </div>
+          <address className="text-center text-sm text-white/70 not-italic md:text-right md:text-base">
+            <a
+              href={`mailto:${t.footer.contact.email}`}
+              className="block font-medium text-white transition hover:text-white"
+            >
+              {t.footer.contact.emailLabel}: {t.footer.contact.email}
+            </a>
+            <div>{t.footer.contact.locationLabel}: {t.footer.contact.location}</div>
+          </address>
         </div>
 
-        <div className="pt-8 border-t border-gray-700">
-          <div className="flex flex-col md:flex-row justify-between items-center">
-            <p className="mb-4 md:mb-0">{t.footer.copyright}</p>
-            <div className="flex items-center space-x-4 text-sm">
-              <a
-                href={lang === 'fr' ? '/fr/politique-confidentialite' : '/privacy'}
-                className="hover:text-[#2280FF] transition-colors"
-              >
-                {t.footer.privacy}
-              </a>
-              <p>{t.footer.curiosity}</p>
-            </div>
-          </div>
+        <div className="mt-6 border-t border-white/10 pt-4">
+          <p className="text-center text-xs text-white/50 md:text-left">
+            {t.footer.copyright}
+          </p>
         </div>
       </div>
     </footer>

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -141,13 +141,11 @@ export const en = {
       }
     ]
   },
-  finalCTA: {
-    title: 'Stay compliant. Stay ahead.',
-    sub: 'Join the weekly newsletter for proven automation tactics built for Québec SMBs.',
-    primary: 'Join Newsletter',
-    primaryHref: '/en/newsletter',
-    secondary: 'See Packs',
-    secondaryHref: '/packs'
+  finalcta: {
+    headline: 'Stay compliant. Stay ahead.',
+    subtext: 'Get one actionable tactic each week to automate and stay compliant.',
+    cta: 'Join Newsletter',
+    href: '/en/newsletter'
   },
   stickyCta: 'Join Newsletter',
   trustBadge: 'Built for Québec • Demo-first • Fully bilingual & Law 96\u2013compliant',
@@ -199,15 +197,14 @@ export const en = {
     }
   },
   footer: {
-    blurb: "Bilingual automation for Québec SMBs. Built for today's needs, ready for tomorrow's AI.",
-    language: 'Serving all of Québec • EN/FR',
-    services: 'Services',
-    servicesList: ['Lead Follow-up Automation', 'Appointment Reminders', 'Review Management', 'Bill 96 Compliance'],
-    contact: 'Contact',
-    location: 'Québec, Canada',
-    privacy: 'Privacy Policy',
-    copyright: '© 2024 Simon Paris Consulting. All rights reserved.',
-    curiosity: 'Curious about the next wave of AI for SMBs? Ask Simon.'
+    tagline: 'Bilingual automation for Québec SMBs.',
+    contact: {
+      emailLabel: 'Email',
+      email: 'info@simonparis.ca',
+      locationLabel: 'Based in',
+      location: 'Québec, Canada'
+    },
+    copyright: '© 2024 Simon Paris Consulting'
   }
 };
 export type TranslationKeys = typeof en;

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -141,13 +141,11 @@ const fr: TranslationKeys = {
       }
     ]
   },
-  finalCTA: {
-    title: 'Restez conforme. Restez en avance.',
-    sub: 'Rejoignez l’infolettre hebdo pour des tactiques d’automatisation pensées pour les PME québécoises.',
-    primary: 'Joindre l’infolettre',
-    primaryHref: '/fr/newsletter',
-    secondary: 'Voir les packs',
-    secondaryHref: '/packs'
+  finalcta: {
+    headline: 'Restez conforme. Restez à jour.',
+    subtext: 'Recevez chaque semaine une tactique concrète pour automatiser et rester conforme.',
+    cta: 'Joindre l’infolettre',
+    href: '/fr/newsletter'
   },
   stickyCta: 'Joindre l’infolettre',
   trustBadge: 'Conçu pour le Québec • Démo en direct • Bilingue et conforme à la Loi 96',
@@ -199,15 +197,14 @@ const fr: TranslationKeys = {
     }
   },
   footer: {
-    blurb: 'Automatisation bilingue pour les PME du Québec. Conçu pour aujourd’hui, prêt pour l’IA de demain.',
-    language: 'Pour tout le Québec • FR/EN',
-    services: 'Services',
-    servicesList: ['Suivi des clients potentiels', 'Rappels de rendez-vous', 'Gestion des avis', 'Conformité Loi 96'],
-    contact: 'Contact',
-    location: 'Québec, Canada',
-    privacy: 'Politique de confidentialité',
-    copyright: '© 2024 Simon Paris Consulting. Tous droits réservés.',
-    curiosity: 'Curieux des prochaines avancées IA pour PME ? Écrivez à Simon.'
+    tagline: 'Automatisation bilingue pour les PME du Québec.',
+    contact: {
+      emailLabel: 'Courriel',
+      email: 'info@simonparis.ca',
+      locationLabel: 'Basé à',
+      location: 'Québec, Canada'
+    },
+    copyright: '© 2024 Simon Paris Consulting'
   }
 };
 


### PR DESCRIPTION
## Summary
- Replace the final CTA with a flat navy banner that mirrors the footer background and focuses on one newsletter signup
- Simplify the footer into brand, tagline, and contact info only while matching the CTA styling
- Update English and French translation keys to support the lean CTA copy and remove redundant footer newsletter strings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e07de2d9bc8323ad27c99a16485e35