### PR TITLE
Restore compliance link in footer

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -184,9 +184,17 @@ export const Footer: React.FC<{ langToggle?: { fr: string; en: string } }> = ({
         </div>
 
         <div className="mt-6 border-t border-white/10 pt-4">
-          <p className="text-center text-[11px] text-white/45 md:text-left">
-            {t.footer.copyright}
-          </p>
+          <div className="flex flex-col items-center gap-2 text-center md:flex-row md:justify-between md:text-left">
+            <a
+              href={t.footer.compliance.href}
+              className="text-xs font-medium text-white/70 transition hover:text-white md:text-sm"
+            >
+              {t.footer.compliance.label}
+            </a>
+            <p className="text-[11px] text-white/45 md:text-left">
+              {t.footer.copyright}
+            </p>
+          </div>
         </div>
       </div>
     </footer>

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -214,6 +214,10 @@ export const en = {
   },
   footer: {
     tagline: 'Bilingual automation for Québec SMBs.',
+    compliance: {
+      label: 'Privacy & Compliance',
+      href: '/privacy'
+    },
     contact: {
       emailLabel: 'Email',
       email: 'info@simonparis.ca',

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -215,6 +215,10 @@ const fr: TranslationKeys = {
   },
   footer: {
     tagline: 'Automatisation bilingue pour les PME du Québec.',
+    compliance: {
+      label: 'Conformité & confidentialité',
+      href: '/fr/politique-confidentialite'
+    },
     contact: {
       emailLabel: 'Courriel',
       email: 'info@simonparis.ca',


### PR DESCRIPTION
## Summary
- restore the footer compliance link and style it with localized copy
- add English and French translation entries for the compliance destination

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e10784619083238fc93f5c48e09d1b