### PR TITLE
Redesign hero section with new positioning

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,12 +20,16 @@ import MiniAuditCTA from './components/MiniAuditCTA';
 const Hero = () => {
   const { t } = useLanguage();
   const hero = t.hero;
-  const taglineParts = hero.tagline.includes('•')
-    ? hero.tagline.split('•').map(part => part.trim()).filter(Boolean)
-    : [hero.tagline];
+  const titleSegments = hero.title
+    .split('.')
+    .map(segment => segment.trim())
+    .filter(Boolean);
 
   return (
-    <section id="hero" className="relative isolate overflow-hidden bg-[#0B1320] text-white">
+    <section
+      id="hero"
+      className="relative isolate flex min-h-[90vh] items-center justify-center overflow-hidden bg-[#0B1320] text-white"
+    >
       <div className="pointer-events-none absolute inset-0">
         <div className="absolute inset-0 bg-[radial-gradient(120%_120%_at_0%_0%,rgba(34,128,255,0.2),rgba(11,19,32,0)_60%),radial-gradient(120%_120%_at_85%_15%,rgba(19,158,156,0.25),rgba(11,19,32,0)_65%)] opacity-90" />
         <div className="absolute inset-0 bg-[linear-gradient(140deg,rgba(255,255,255,0.08),transparent_50%)] mix-blend-screen" />
@@ -33,30 +37,33 @@ const Hero = () => {
         <div className="absolute bottom-[-8rem] right-[-6rem] h-[28rem] w-[28rem] rounded-full bg-[#139E9C]/16 blur-[150px]" />
       </div>
 
-      <div className="relative z-10 mx-auto flex min-h-[90vh] max-w-7xl flex-col justify-center px-4 pb-20 pt-28 sm:px-6 lg:px-8 lg:pt-32">
-        <div className="max-w-3xl space-y-10">
-          <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs font-semibold uppercase tracking-[0.28em] text-white/55">
-            {taglineParts.map((part, index) => (
-              <React.Fragment key={`${part}-${index}`}>
-                {index > 0 && <span className="text-white/30">•</span>}
-                <span>{part}</span>
-              </React.Fragment>
-            ))}
-          </div>
+      <div className="relative z-10 mx-auto w-full max-w-[60rem] px-4 py-24 text-center sm:px-6 lg:px-8 lg:py-32">
+        <div className="mx-auto flex max-w-3xl flex-col items-center gap-8 sm:gap-10">
+          <h1 className="text-balance text-[clamp(2rem,6vw,3.75rem)] font-semibold leading-[1.08] tracking-tight sm:leading-[1.12]">
+            {titleSegments.map((segment, index) => {
+              const isHighlight = hero.highlight && segment.toLowerCase() === hero.highlight.toLowerCase();
+              const text = `${segment}.`;
+              return (
+                <span key={`${segment}-${index}`} className={`block ${isHighlight ? 'text-[#139E9C]' : ''}`}>
+                  {text}
+                </span>
+              );
+            })}
+          </h1>
 
-          <div className="space-y-6">
-            <h1 className="text-[clamp(1.5rem,6vw,4rem)] font-semibold leading-[1.05] tracking-tight">
-              <span className="block">{hero.headline.line1}</span>
-              <span className="block text-[#139E9C]">{hero.headline.line2}</span>
-              <span className="block">{hero.headline.line3}</span>
-            </h1>
+          <p className="text-balance text-base leading-relaxed text-white/80 sm:text-lg sm:leading-relaxed">
+            {hero.subtitle}
+          </p>
 
-            <p className="text-base leading-relaxed text-white/80 sm:text-lg">{hero.subtext}</p>
-          </div>
-
-          <div>
-            <a href={hero.cta.href} className="btn-primary w-full sm:w-auto">
-              {t.cta.bookAudit}
+          <div className="mt-2 flex flex-col items-center gap-3">
+            <a href={hero.cta.href} className="btn-primary w-full max-w-xs sm:max-w-none sm:w-auto">
+              {hero.cta.label}
+            </a>
+            <a
+              href={hero.secondaryCta.href}
+              className="text-sm font-medium text-white/70 transition hover:text-white"
+            >
+              {hero.secondaryCta.label}
             </a>
           </div>
         </div>

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -8,16 +8,17 @@ export const en = {
     cta: 'Diagnostic Éclair'
   },
   hero: {
-    tagline: 'For Québec SMBs • Law 25 ready • Zero jargon',
-    headline: {
-      line1: 'Automate the busywork.',
-      line2: 'Protect your margins.',
-      line3: 'Stay Law 25 ready.'
-    },
-    subtext:
-      'Bilingual automations that answer leads, chase invoices, and document consent—without adding tools your team won’t use.',
+    title: 'Automate the busywork. Protect your margins. Stay Law 25 ready.',
+    highlight: 'Protect your margins',
+    subtitle:
+      'I design and test real AI automations — then share what works for Québec SMBs. From content to compliance, I help you save hours and stay ahead.',
     cta: {
+      label: 'Book Free Mini Audit',
       href: 'https://cal.com/simonparis/mini-audit'
+    },
+    secondaryCta: {
+      label: 'Not ready yet? Join the newsletter →',
+      href: '/en/newsletter'
     }
   },
   cta: {

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -9,16 +9,17 @@ const fr: TranslationKeys = {
     cta: 'Diagnostic Éclair'
   },
   hero: {
-    tagline: 'Pour les PME du Québec • Loi 25 prête • Zéro jargon',
-    headline: {
-      line1: 'Automatisez les tâches lourdes.',
-      line2: 'Protégez vos marges.',
-      line3: 'Restez conforme à la Loi 25.'
-    },
-    subtext:
-      'Des automatisations bilingues qui répondent aux leads, relancent les factures et documentent les consentements — sans ajouter d’outils que votre équipe n’utilisera pas.',
+    title: 'Automatisez les tâches lourdes. Protégez vos marges. Restez conforme à la Loi 25.',
+    highlight: 'Protégez vos marges',
+    subtitle:
+      'Je conçois et teste des automatisations IA concrètes — puis je partage ce qui fonctionne pour les PME du Québec. De la création de contenu à la conformité, j’aide les équipes à gagner du temps et à rester en avance.',
     cta: {
+      label: 'Réserver un Diagnostic Éclair',
       href: 'https://cal.com/simonparis/diagnostic'
+    },
+    secondaryCta: {
+      label: 'Pas prêt? Rejoignez l’infolettre →',
+      href: '/fr/infolettre'
     }
   },
   cta: {


### PR DESCRIPTION
## Summary
- center the homepage hero with a 960px layout, responsive typography, and refreshed CTA stack to focus on Simon Paris’ AI automation expertise
- update bilingual hero copy with new title, subtitle, CTA, and newsletter link while keeping highlight styling consistent

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e17009141c83239f35bf53f7defae6