### PR TITLE
Enhance mini audit CTA styling

### DIFF
--- a/src/components/MiniAuditCTA.tsx
+++ b/src/components/MiniAuditCTA.tsx
@@ -7,35 +7,35 @@ const MiniAuditCTA: React.FC = () => {
   const bullets: string[] = t.cta.audit.bullets;
 
   return (
-    <section className="relative bg-section-gradient-bottom py-20 lg:py-28">
-      <div className="mx-auto max-w-[700px] px-4 sm:px-6 lg:px-8">
-        <div className="mini-audit-card group relative overflow-hidden text-white">
+    <section className="relative bg-section-gradient-bottom py-24 lg:py-32">
+      <div className="mx-auto flex w-full justify-center px-4 sm:px-6 lg:px-8">
+        <div className="mini-audit-card group relative w-full max-w-[1100px] overflow-hidden text-white lg:w-4/5">
           <div className="pointer-events-none absolute inset-0">
-            <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(34,128,255,0.2),transparent_60%)]" />
-            <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom,_rgba(19,158,156,0.28),transparent_65%)]" />
-            <div className="absolute -bottom-24 left-1/2 h-64 w-64 -translate-x-1/2 rounded-full bg-[#139E9C]/25 blur-[140px]" />
+            <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(34,128,255,0.18),transparent_60%)]" />
+            <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom,_rgba(19,158,156,0.22),transparent_65%)]" />
+            <div className="absolute -bottom-24 left-1/2 h-72 w-72 -translate-x-1/2 rounded-full bg-[#139E9C]/25 blur-[160px]" />
           </div>
 
-          <div className="relative flex flex-col gap-8 px-6 py-8 text-center sm:px-8 sm:py-10 lg:px-14 lg:py-12">
-            <h2 className="text-[clamp(1.5rem,4vw,2.5rem)] font-semibold leading-tight text-white">
+          <div className="relative mx-auto flex flex-col items-center gap-10 px-8 py-12 text-center sm:px-10 sm:py-14 lg:max-w-4xl lg:px-16 lg:py-16">
+            <h2 className="text-[clamp(1.75rem,3.8vw,2.75rem)] font-semibold leading-tight text-[#F4F6F8]">
               {t.cta.audit.title}
             </h2>
 
-            <ul className="flex flex-col gap-4 text-left text-base leading-relaxed text-white/85 sm:text-lg">
+            <ul className="flex w-full flex-col gap-4 text-left text-base leading-relaxed text-[#C7D0D8] sm:text-lg">
               {bullets.map((item, index) => (
                 <li
                   key={index}
                   className="mini-audit-list-item flex items-start gap-3"
                   style={{ animationDelay: `${index * 0.1 + 0.15}s` }}
                 >
-                  <CheckCircle2 className="mt-1 h-6 w-6 flex-shrink-0 text-[#139E9C] drop-shadow-[0_0_6px_rgba(19,158,156,0.35)]" />
-                  <span className="text-white/90">{item}</span>
+                  <CheckCircle2 className="mt-1 h-6 w-6 flex-shrink-0 text-[#139E9C] drop-shadow-[0_0_12px_rgba(19,158,156,0.45)]" />
+                  <span className="text-[#C7D0D8]">{item}</span>
                 </li>
               ))}
             </ul>
 
             <div className="flex flex-col items-center gap-4">
-              <span className="text-sm font-medium uppercase tracking-[0.2em] text-[#8be9e7]">
+              <span className="text-sm font-medium uppercase tracking-[0.2em] text-[#8AE8E6]">
                 {t.cta.audit.timeline}
               </span>
               <a href={t.hero.cta.href} className="btn-primary btn-primary--audit">

--- a/src/components/MiniAuditCTA.tsx
+++ b/src/components/MiniAuditCTA.tsx
@@ -7,25 +7,29 @@ const MiniAuditCTA: React.FC = () => {
   const bullets: string[] = t.cta.audit.bullets;
 
   return (
-    <section className="relative py-20 lg:py-28">
-      <div className="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
-        <div className="relative overflow-hidden rounded-3xl bg-[#0e1a25] p-8 sm:p-10 lg:p-12 text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]">
+    <section className="relative bg-section-gradient-bottom py-20 lg:py-28">
+      <div className="mx-auto max-w-[700px] px-4 sm:px-6 lg:px-8">
+        <div className="mini-audit-card group relative overflow-hidden text-white">
           <div className="pointer-events-none absolute inset-0">
             <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(34,128,255,0.2),transparent_60%)]" />
             <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom,_rgba(19,158,156,0.28),transparent_65%)]" />
             <div className="absolute -bottom-24 left-1/2 h-64 w-64 -translate-x-1/2 rounded-full bg-[#139E9C]/25 blur-[140px]" />
           </div>
 
-          <div className="relative flex flex-col gap-8 text-center">
-            <h2 className="text-[clamp(1.5rem,4vw,2.75rem)] font-semibold leading-tight text-white">
+          <div className="relative flex flex-col gap-8 px-6 py-8 text-center sm:px-8 sm:py-10 lg:px-14 lg:py-12">
+            <h2 className="text-[clamp(1.5rem,4vw,2.5rem)] font-semibold leading-tight text-white">
               {t.cta.audit.title}
             </h2>
 
-            <ul className="flex flex-col gap-4 text-left text-base text-white/85 sm:text-lg">
+            <ul className="flex flex-col gap-4 text-left text-base leading-relaxed text-white/85 sm:text-lg">
               {bullets.map((item, index) => (
-                <li key={index} className="flex items-start gap-3">
-                  <CheckCircle2 className="mt-1 h-6 w-6 flex-shrink-0 text-[#4fd5d2]" />
-                  <span>{item}</span>
+                <li
+                  key={index}
+                  className="mini-audit-list-item flex items-start gap-3"
+                  style={{ animationDelay: `${index * 0.1 + 0.15}s` }}
+                >
+                  <CheckCircle2 className="mt-1 h-6 w-6 flex-shrink-0 text-[#139E9C] drop-shadow-[0_0_6px_rgba(19,158,156,0.35)]" />
+                  <span className="text-white/90">{item}</span>
                 </li>
               ))}
             </ul>
@@ -34,7 +38,7 @@ const MiniAuditCTA: React.FC = () => {
               <span className="text-sm font-medium uppercase tracking-[0.2em] text-[#8be9e7]">
                 {t.cta.audit.timeline}
               </span>
-              <a href={t.hero.cta.href} className="btn-primary">
+              <a href={t.hero.cta.href} className="btn-primary btn-primary--audit">
                 {t.cta.bookAudit}
               </a>
             </div>

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -50,11 +50,11 @@ export const en = {
     audit: {
       title: 'Here’s what we identify in your 20-minute Mini Audit.',
       bullets: [
-        'The workflow that is leaking the most time or revenue.',
-        'The quick-win automation that fits your current stack.',
-        'The compliance risks to close before Law 25 fines.'
+        "The workflow that’s costing the most time or revenue.",
+        'A quick-win automation that fits your current tools.',
+        'Any compliance risks to fix before Law 25 fines.'
       ],
-      timeline: 'Typical setup: 5–10 business days.'
+      timeline: 'Typical setup: 5 – 10 business days.'
     }
   },
   growth: {

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -52,7 +52,7 @@ const fr: TranslationKeys = {
       title: 'Voici ce que l’on identifie dans votre Mini Audit de 20 minutes.',
       bullets: [
         'Le processus qui vous fait perdre le plus de temps ou de revenus.',
-        'L’automatisation à implanter rapidement dans vos outils actuels.',
+        'L’automatisation rapide à implanter dans vos outils actuels.',
         'Les risques de conformité à corriger avant les amendes de la Loi 25.'
       ],
       timeline: 'Installation typique : 5 à 10 jours ouvrables.'

--- a/src/index.css
+++ b/src/index.css
@@ -161,15 +161,22 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .mini-audit-card {
+  position: relative;
   border-radius: 20px;
-  background: linear-gradient(135deg, #0f1e2e 0%, #112b3c 100%);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25), inset 0 0 12px rgba(19, 158, 156, 0.3);
-  transition: transform 0.25s ease, box-shadow 0.25s ease;
+  background: linear-gradient(135deg, #0b1827 0%, #0f2635 55%, #12414a 100%);
+  box-shadow:
+    0 8px 25px rgba(0, 0, 0, 0.25),
+    0 0 0 1px rgba(19, 158, 156, 0.25),
+    0 0 24px rgba(19, 158, 156, 0.22);
+  transition: all 0.3s ease;
 }
 
 .mini-audit-card:hover {
   transform: translateY(-4px);
-  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35), inset 0 0 14px rgba(19, 158, 156, 0.36);
+  box-shadow:
+    0 12px 35px rgba(0, 0, 0, 0.35),
+    0 0 0 1px rgba(19, 158, 156, 0.32),
+    0 0 30px rgba(19, 158, 156, 0.3);
 }
 
 .mini-audit-list-item {
@@ -178,15 +185,15 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .btn-primary--audit {
-  background: linear-gradient(90deg, #139e9c 0%, #11b8b6 100%);
-  box-shadow: 0 10px 26px rgba(19, 158, 156, 0.45);
+  background: linear-gradient(110deg, #139e9c 0%, #0fc2c0 45%, #13f4f2 100%);
+  box-shadow: 0 10px 26px rgba(19, 158, 156, 0.38), 0 0 16px rgba(19, 158, 156, 0.45);
   background-size: 200% 200%;
   transition: transform 0.3s ease, box-shadow 0.3s ease, background-position 0.4s ease;
 }
 
 .btn-primary--audit:hover {
   background-position: 100% 50%;
-  box-shadow: 0 4px 12px rgba(19, 158, 156, 0.4);
+  box-shadow: 0 4px 18px rgba(19, 158, 156, 0.5), 0 0 22px rgba(19, 158, 156, 0.55);
 }
 
 .btn-primary--audit:focus-visible {

--- a/src/index.css
+++ b/src/index.css
@@ -149,6 +149,50 @@ h1, h2, h3, h4, h5, h6 {
   50% { box-shadow: 0 0 30px rgba(17, 230, 176, 0.5); }
 }
 
+@keyframes mini-audit-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.mini-audit-card {
+  border-radius: 20px;
+  background: linear-gradient(135deg, #0f1e2e 0%, #112b3c 100%);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25), inset 0 0 12px rgba(19, 158, 156, 0.3);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.mini-audit-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35), inset 0 0 14px rgba(19, 158, 156, 0.36);
+}
+
+.mini-audit-list-item {
+  opacity: 0;
+  animation: mini-audit-fade-in 0.6s ease forwards;
+}
+
+.btn-primary--audit {
+  background: linear-gradient(90deg, #139e9c 0%, #11b8b6 100%);
+  box-shadow: 0 10px 26px rgba(19, 158, 156, 0.45);
+  background-size: 200% 200%;
+  transition: transform 0.3s ease, box-shadow 0.3s ease, background-position 0.4s ease;
+}
+
+.btn-primary--audit:hover {
+  background-position: 100% 50%;
+  box-shadow: 0 4px 12px rgba(19, 158, 156, 0.4);
+}
+
+.btn-primary--audit:focus-visible {
+  box-shadow: 0 0 0 3px rgba(19, 158, 156, 0.35), 0 12px 32px rgba(19, 158, 156, 0.45);
+}
+
 .animate-float {
   animation: float 4s ease-in-out infinite;
 }
@@ -345,11 +389,22 @@ h1, h2, h3, h4, h5, h6 {
   .animate-pulse-glow {
     animation: none;
   }
-  
+
   .btn-primary:hover,
   .btn-secondary:hover,
   .btn-outline:hover,
-  .card-dark:hover {
+  .card-dark:hover,
+  .mini-audit-card:hover {
+    transform: none;
+  }
+
+  .mini-audit-card {
+    transition: none;
+  }
+
+  .mini-audit-list-item {
+    animation: none;
+    opacity: 1;
     transform: none;
   }
 }


### PR DESCRIPTION
## Summary
- refresh the mini audit CTA container with a premium gradient card, layered shadows, and responsive spacing while keeping existing content
- animate the benefit list with teal checkmarks, staggered fade-ins, and update the surrounding section background to match the problems gradient
- add a dedicated gradient hover treatment for the CTA button and ensure reduced motion preferences are respected

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e17f47745483238a107d5d09cc99d9