### PR TITLE
Add lead capture card to What I Build section

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -104,6 +104,12 @@ export const en = {
         tagline: 'Centralizes contacts, projects, and communication.',
         description: 'Airtable-powered hub used to run daily operations.',
         status: 'running'
+      },
+      {
+        title: 'Lead Capture & Scheduling Flow',
+        tagline: 'Routes form submissions and bookings automatically.',
+        description: 'Tally → n8n → Airtable → Cal.com — every lead tracked instantly.',
+        status: 'running'
       }
     ]
   },

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -110,6 +110,18 @@ export const en = {
         tagline: 'Routes form submissions and bookings automatically.',
         description: 'Tally → n8n → Airtable → Cal.com — every lead tracked instantly.',
         status: 'running'
+      },
+      {
+        title: 'AI Avatar Video Engine',
+        tagline: 'Creates bilingual videos to boost SMB visibility.',
+        description: 'Powered by Heygen + custom AI scripts for localized content.',
+        status: 'indev'
+      },
+      {
+        title: 'AI Receptionist (Prototype)',
+        tagline: '24/7 bilingual assistant for clinics and small businesses.',
+        description: 'Books appointments, answers questions, and keeps everything compliant.',
+        status: 'prototype'
       }
     ]
   },

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -111,6 +111,18 @@ const fr: TranslationKeys = {
         tagline: 'Dirige automatiquement formulaires et réservations.',
         description: 'Tally → n8n → Airtable → Cal.com — chaque piste suivie instantanément.',
         status: 'running'
+      },
+      {
+        title: 'Générateur de vidéos IA (avatars)',
+        tagline: 'Crée des vidéos bilingues pour renforcer la présence des PME.',
+        description: 'Propulsé par Heygen et des scripts IA personnalisés pour du contenu localisé.',
+        status: 'indev'
+      },
+      {
+        title: 'Réceptionniste IA (prototype)',
+        tagline: 'Assistant bilingue 24/7 pour cliniques et petites entreprises.',
+        description: 'Planifie des rendez-vous, répond aux questions et assure la conformité.',
+        status: 'prototype'
       }
     ]
   },

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -105,6 +105,12 @@ const fr: TranslationKeys = {
         tagline: 'Centralise vos contacts, projets et communications.',
         description: 'Tableau Airtable utilisé pour gérer les opérations quotidiennes.',
         status: 'running'
+      },
+      {
+        title: 'Flux de capture et de planification',
+        tagline: 'Dirige automatiquement formulaires et réservations.',
+        description: 'Tally → n8n → Airtable → Cal.com — chaque piste suivie instantanément.',
+        status: 'running'
       }
     ]
   },


### PR DESCRIPTION
## Summary
- add a lead capture & scheduling flow card to the What I Build section
- provide English and French translations for the new card

## Testing
- npm test (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68e1b9ec99a08323ab4b9e39e2a957e8