### PR TITLE
feat: rebuild Proof Lab portfolio grid

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,6 @@ import {
   MessageSquare,
   CheckCircle,
   ShieldCheck,
-  Send,
   LayoutDashboard,
   CalendarCheck,
   Video,
@@ -15,20 +14,13 @@ import {
   CalendarClock,
   ShieldAlert,
   Link2,
-  Shield
+  Shield,
+  FlaskConical
 } from 'lucide-react';
 import { Header, Footer } from './components/Layout';
 import PartnerBar from './components/PartnerBar';
 import FinalCTA from './components/FinalCTA';
 import MiniAuditCTA from './components/MiniAuditCTA';
-
-const WHAT_I_BUILD_STATUS = {
-  running: { accent: '#16a34a' },
-  indev: { accent: '#f59e0b' },
-  prototype: { accent: '#64748b' }
-} as const;
-
-type WhatIBuildStatus = keyof typeof WHAT_I_BUILD_STATUS;
 
 // Hero Component
 const Hero = () => {
@@ -167,8 +159,8 @@ const ProblemSection = () => {
   );
 };
 
-// What I Build Component
-const WhatIBuild = () => {
+// Proof Lab Component
+const ProofLab = () => {
   const [isVisible, setIsVisible] = useState(false);
   const sectionRef = useRef<HTMLElement>(null);
   const { t } = useLanguage();
@@ -183,79 +175,102 @@ const WhatIBuild = () => {
       { threshold: 0.3 }
     );
 
-    if (sectionRef.current) {
-      observer.observe(sectionRef.current);
+    const current = sectionRef.current;
+    if (current) {
+      observer.observe(current);
     }
 
     return () => observer.disconnect();
   }, []);
 
-  const cards = t.whatIBuild.cards.map((card, index) => ({
-    ...card,
-    icon: [Send, ShieldCheck, LayoutDashboard, CalendarCheck, Video, Headset][index]
-  }));
+  const placeholderIcons = [FlaskConical, ShieldCheck, LayoutDashboard, CalendarCheck, Video, Headset];
+  const formatHighlight = (value: string) =>
+    value.replace(/<highlight>(.*?)<\/highlight>/g, '<span class="text-[#139E9C] font-semibold">$1</span>');
 
-  const headingHtml = t.whatIBuild.heading.replace(
-    /<accent>(.*?)<\/accent>/g,
-    '<span class="text-teal-600">$1</span>'
-  );
+  const headingHtml = formatHighlight(t.proofLab.title);
+  const cards = t.proofLab.cards.map((card, index) => ({
+    ...card,
+    icon: placeholderIcons[index] ?? FlaskConical
+  }));
 
   return (
     <section
       ref={sectionRef}
-      className="relative overflow-hidden py-20 lg:py-28"
-      style={{
-        background:
-          'radial-gradient(800px 300px at 50% 0%, rgba(19,158,156,0.08), transparent 60%), linear-gradient(to bottom, #F9FBFC, #FFFFFF)'
-      }}
+      id="proof-lab"
+      className="relative overflow-hidden bg-section-gradient-bottom py-24 lg:py-32"
     >
-      <div className="relative z-10 mx-auto max-w-7xl px-6 md:px-8">
+      <div className="pointer-events-none absolute inset-0 opacity-60">
+        <div className="absolute inset-0 bg-[radial-gradient(80%_60%_at_50%_0%,rgba(34,128,255,0.12),transparent_65%)]" />
+        <div className="absolute inset-0 bg-[radial-gradient(80%_70%_at_20%_100%,rgba(19,158,156,0.12),transparent_70%)]" />
+      </div>
+
+      <div className="relative z-10 mx-auto max-w-6xl px-6 md:px-8">
         <div
-          className={`flex flex-col gap-8 text-center transition-all duration-1000 ${
+          className={`mx-auto max-w-3xl text-center transition-all duration-1000 ${
             isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'
           }`}
         >
           <h2
-            className="text-3xl font-semibold text-slate-900 md:text-4xl"
+            className="text-balance text-3xl font-semibold text-[#121C2D] md:text-4xl"
             dangerouslySetInnerHTML={{ __html: headingHtml }}
           />
+          <p className="mt-4 text-base leading-relaxed text-slate-600 md:text-lg">{t.proofLab.subtitle}</p>
         </div>
 
-        <div className="mt-12 grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
+        <div
+          className={`mt-14 grid grid-cols-1 gap-6 transition-all duration-1000 sm:grid-cols-2 sm:gap-8 lg:grid-cols-3 lg:gap-10 ${
+            isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'
+          }`}
+        >
           {cards.map((card, index) => {
-            const statusKey = card.status as WhatIBuildStatus;
-            const accentColor = WHAT_I_BUILD_STATUS[statusKey].accent;
-            const accentStyle = { '--accent': accentColor } as React.CSSProperties;
-            const badgeStyle = { '--dot': accentColor } as React.CSSProperties;
+            const CardIcon = card.icon;
+            const hasImage = card.image && typeof card.image === 'object' && 'src' in card.image;
+            const backgroundTone = index % 2 === 0 ? 'bg-white' : 'bg-[#F8FBFB]';
 
             return (
-              <div
+              <article
                 key={card.title}
-                className={`group relative flex h-full flex-col rounded-2xl border border-slate-200/80 bg-white p-6 shadow-[0_4px_14px_rgba(2,6,23,0.06)] transition-all duration-200 before:absolute before:inset-x-0 before:top-0 before:h-[2px] before:rounded-t-2xl before:bg-[var(--accent)] before:content-[''] ${
-                  isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'
-                } hover:-translate-y-1 hover:shadow-[0_10px_28px_rgba(2,6,23,0.12)] hover:ring-1 hover:ring-teal-300/40`}
-                style={{
-                  ...accentStyle,
-                  transitionDelay: isVisible ? '0ms' : `${index * 160}ms`
-                }}
+                className={`group relative flex h-full flex-col overflow-hidden rounded-[1.5rem] border border-white/60 shadow-[0_18px_45px_rgba(18,28,45,0.08)] transition-all duration-500 ease-out ${
+                  backgroundTone
+                } ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'} hover:-translate-y-[2px] hover:opacity-95 hover:shadow-[0_24px_60px_rgba(18,28,45,0.18)]`}
+                style={{ transitionDelay: isVisible ? `${index * 120}ms` : '0ms' }}
               >
-                <div className="icon grid h-10 w-10 place-items-center rounded-xl bg-teal-50 text-teal-700 transition-colors duration-200 group-hover:bg-teal-100 group-hover:text-teal-800">
-                  <card.icon className="h-6 w-6 transition-transform duration-200 group-hover:-translate-y-0.5" />
+                <div className="relative aspect-[16/9] w-full overflow-hidden">
+                  {hasImage && card.image ? (
+                    <img
+                      src={card.image.src}
+                      alt={card.image.alt}
+                      className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-[1.03]"
+                    />
+                  ) : (
+                    <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-[#139E9C] via-[#0F6C8C] to-[#121C2D] transition-all duration-500 group-hover:brightness-110">
+                      <CardIcon className="h-10 w-10 text-white/85" />
+                    </div>
+                  )}
                 </div>
 
-                <div className="mt-4 space-y-3">
-                  <span
-                    className="inline-flex items-center gap-2 rounded-full bg-slate-50 px-2.5 py-1 text-xs font-medium tracking-wide text-slate-700"
-                    style={badgeStyle}
-                  >
-                    <span className="h-1.5 w-1.5 rounded-full" style={{ background: 'var(--dot)' }} />
-                    {t.whatIBuild.badges[statusKey]}
-                  </span>
-                  <h3 className="text-lg font-semibold text-slate-900 md:text-xl">{card.title}</h3>
-                  <p className="text-[17px] font-medium leading-7 text-slate-700">{card.tagline}</p>
-                  <p className="text-[17px] leading-7 text-slate-600 line-clamp-3">{card.description}</p>
+                <div className="flex flex-1 flex-col gap-4 px-6 pb-7 pt-6 md:px-7 md:pt-7">
+                  <h3 className="text-[19px] font-semibold text-[#121C2D]">{card.title}</h3>
+                  <p
+                    className="text-[15px] leading-6 text-slate-700"
+                    dangerouslySetInnerHTML={{ __html: formatHighlight(card.desc) }}
+                  />
+                  <p className="text-[13px] font-medium text-slate-500">{card.status}</p>
+
+                  {card.badges?.length ? (
+                    <div className="mt-auto flex flex-wrap gap-2 pt-2">
+                      {card.badges.map((badge: string) => (
+                        <span
+                          key={badge}
+                          className="inline-flex items-center rounded-full border border-[#139E9C]/20 bg-white/80 px-3 py-1 text-[12px] font-semibold uppercase tracking-wide text-[#139E9C]"
+                        >
+                          {badge}
+                        </span>
+                      ))}
+                    </div>
+                  ) : null}
                 </div>
-              </div>
+              </article>
             );
           })}
         </div>
@@ -542,7 +557,7 @@ function App() {
         <Hero />
         <PartnerBar />
         <ProblemSection />
-        <WhatIBuild />
+        <ProofLab />
         <MiniAuditCTA />
         <OfferCards />
       <ROIMath />

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -79,49 +79,51 @@ export const en = {
     ],
     note: 'All of this is fixable with simple <span class="font-semibold">bilingual automations</span> built for your team.'
   },
-  whatIBuild: {
-    heading: 'Real tools, <accent>built in Québec.</accent>',
-    badges: {
-      running: 'Running',
-      indev: 'In development',
-      prototype: 'Prototype'
-    },
+  proofLab: {
+    title: 'Real tools, <highlight>built in Québec.</highlight>',
+    subtitle: 'Every workflow here started as an internal experiment — refined and ready for real SMBs.',
     cards: [
       {
         title: 'AI Newsletter Engine',
-        tagline: 'Automates bilingual newsletter creation and delivery.',
-        description: 'Built with n8n + Brevo to publish weekly updates without manual work.',
-        status: 'running'
+        desc: 'Automates <highlight>bilingual newsletter creation</highlight> and delivery.',
+        status: 'Built in Québec — saves hours each week.',
+        badges: ['🧠 AI-powered', '💬 Bilingual'],
+        image: null as { src: string; alt: string } | null
       },
       {
         title: 'Compliance Tracker (Law 25)',
-        tagline: 'Logs every consent and timestamp automatically.',
-        description: 'Bilingual, audit-ready, and built for Québec SMBs.',
-        status: 'running'
+        desc: 'Logs every consent automatically with <highlight>audit-ready proof</highlight>.',
+        status: 'Bilingual & audit-ready for Québec SMBs.',
+        badges: ['🔒 Law 25 Ready', '⚙️ Automated'],
+        image: null as { src: string; alt: string } | null
       },
       {
         title: 'CRM Command Center',
-        tagline: 'Centralizes contacts, projects, and communication.',
-        description: 'Airtable-powered hub used to run daily operations.',
-        status: 'running'
+        desc: 'Centralizes contacts, projects, and <highlight>day-to-day communication</highlight>.',
+        status: 'Keeps your team aligned without extra tools.',
+        badges: ['⚙️ Automated', '💬 Bilingual'],
+        image: null as { src: string; alt: string } | null
       },
       {
         title: 'Lead Capture & Scheduling Flow',
-        tagline: 'Routes form submissions and bookings automatically.',
-        description: 'Tally → n8n → Airtable → Cal.com — every lead tracked instantly.',
-        status: 'running'
+        desc: 'Routes form submissions and bookings <highlight>into one automation</highlight>.',
+        status: 'Never lose a lead again.',
+        badges: ['⚙️ Automated', '🔒 Law 25 Ready'],
+        image: null as { src: string; alt: string } | null
       },
       {
         title: 'AI Avatar Video Engine',
-        tagline: 'Creates bilingual videos to boost SMB visibility.',
-        description: 'Powered by Heygen + custom AI scripts for localized content.',
-        status: 'indev'
+        desc: 'Creates bilingual videos powered by <highlight>AI scripts + Heygen</highlight>.',
+        status: 'Powered by AI scripts + Heygen.',
+        badges: ['🧠 AI-powered', '💬 Bilingual'],
+        image: null as { src: string; alt: string } | null
       },
       {
         title: 'AI Receptionist (Prototype)',
-        tagline: '24/7 bilingual assistant for clinics and small businesses.',
-        description: 'Books appointments, answers questions, and keeps everything compliant.',
-        status: 'prototype'
+        desc: 'A 24/7 assistant that <highlight>books appointments</highlight> and tracks consent.',
+        status: 'Built for clinics & service SMBs.',
+        badges: ['🧠 AI-powered', '🔒 Law 25 Ready'],
+        image: null as { src: string; alt: string } | null
       }
     ]
   },

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -80,49 +80,51 @@ const fr: TranslationKeys = {
     ],
     note: 'Tout cela se règle avec des <span class="font-semibold">automatisations bilingues</span> pensées pour votre équipe.'
   },
-  whatIBuild: {
-    heading: 'Des outils réels, <accent>conçus au Québec.</accent>',
-    badges: {
-      running: 'En production',
-      indev: 'En développement',
-      prototype: 'Prototype'
-    },
+  proofLab: {
+    title: 'Des outils réels, <highlight>conçus au Québec.</highlight>',
+    subtitle: 'Chaque flux est né d’une expérimentation interne — peaufiné et prêt pour les PME québécoises.',
     cards: [
       {
-        title: 'Moteur d’infolettres IA',
-        tagline: 'Automatise la création et l’envoi d’infolettres bilingues.',
-        description: 'Construit avec n8n + Brevo pour publier chaque semaine sans effort.',
-        status: 'running'
+        title: 'Moteur d’infolettre IA',
+        desc: 'Automatise la <highlight>création et l’envoi bilingues</highlight> des infolettres.',
+        status: 'Conçu au Québec — fait gagner des heures chaque semaine.',
+        badges: ['🧠 IA intégrée', '💬 Bilingue'],
+        image: null as { src: string; alt: string } | null
       },
       {
-        title: 'Journal de conformité (Loi 25)',
-        tagline: 'Enregistre et horodate chaque consentement automatiquement.',
-        description: 'Bilingue, prêt pour l’audit et adapté aux PME du Québec.',
-        status: 'running'
+        title: 'Suivi de conformité (Loi 25)',
+        desc: 'Consigne automatiquement <highlight>chaque consentement</highlight>.',
+        status: 'Bilingue et prêt pour les PME québécoises.',
+        badges: ['🔒 Prêt pour la Loi 25', '⚙️ Automatisé'],
+        image: null as { src: string; alt: string } | null
       },
       {
-        title: 'Centre de contrôle CRM',
-        tagline: 'Centralise vos contacts, projets et communications.',
-        description: 'Tableau Airtable utilisé pour gérer les opérations quotidiennes.',
-        status: 'running'
+        title: 'Centre de commande CRM',
+        desc: 'Centralise contacts, projets et <highlight>communications quotidiennes</highlight>.',
+        status: 'Maintient votre équipe alignée sans ajouter d’outils.',
+        badges: ['⚙️ Automatisé', '💬 Bilingue'],
+        image: null as { src: string; alt: string } | null
       },
       {
         title: 'Flux de capture et de planification',
-        tagline: 'Dirige automatiquement formulaires et réservations.',
-        description: 'Tally → n8n → Airtable → Cal.com — chaque piste suivie instantanément.',
-        status: 'running'
+        desc: 'Achemine formulaires et rendez-vous <highlight>automatiquement</highlight>.',
+        status: 'Ne perdez plus aucun lead.',
+        badges: ['⚙️ Automatisé', '🔒 Prêt pour la Loi 25'],
+        image: null as { src: string; alt: string } | null
       },
       {
-        title: 'Générateur de vidéos IA (avatars)',
-        tagline: 'Crée des vidéos bilingues pour renforcer la présence des PME.',
-        description: 'Propulsé par Heygen et des scripts IA personnalisés pour du contenu localisé.',
-        status: 'indev'
+        title: 'Moteur vidéo IA',
+        desc: 'Crée des vidéos bilingues propulsées par <highlight>Heygen + scripts IA</highlight>.',
+        status: 'Propulsé par Heygen + scripts IA.',
+        badges: ['🧠 IA intégrée', '💬 Bilingue'],
+        image: null as { src: string; alt: string } | null
       },
       {
-        title: 'Réceptionniste IA (prototype)',
-        tagline: 'Assistant bilingue 24/7 pour cliniques et petites entreprises.',
-        description: 'Planifie des rendez-vous, répond aux questions et assure la conformité.',
-        status: 'prototype'
+        title: 'Réceptionniste IA (Prototype)',
+        desc: 'Assistant 24/7 qui <highlight>prend des rendez-vous</highlight> et gère les consentements.',
+        status: 'Idéal pour les cliniques et entreprises de services.',
+        badges: ['🧠 IA intégrée', '🔒 Prêt pour la Loi 25'],
+        image: null as { src: string; alt: string } | null
       }
     ]
   },


### PR DESCRIPTION
## Summary
- replace the What I Build section with a Proof Lab-inspired portfolio grid including responsive visuals, hover motion, and gradient placeholders
- add bilingual Proof Lab copy, highlight markup, and badge metadata to the translation files for full i18n support

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1c4fb06e08323b89aa83efd731080