### PR TITLE
Update hero messaging for speed-to-lead focus

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -8,12 +8,12 @@ export const en = {
     cta: 'Diagnostic Éclair'
   },
   hero: {
-    title: 'Automate the busywork. Protect your margins. Stay Law 25 ready.',
-    highlight: 'Protect your margins',
+    title: 'Win more Québec clients with 5-minute follow-ups. Stay Law 25 compliant automatically.',
+    highlight: 'Win more Québec clients with 5-minute follow-ups',
     subtitle:
-      'I design and test real AI automations — then share what works for Québec SMBs. From content to compliance, I help you save hours and stay ahead.',
+      'I help Québec clinics, trades, wellness teams, and professional services reply to new inquiries in under 5 minutes with bilingual automations trusted by local owners. Book your free 20-minute Diagnostic Éclair to uncover your #1 sales/time leak and stay Law 25 compliant.',
     cta: {
-      label: 'Book Free Mini Audit',
+      label: 'Book Your Free 20-min Diagnostic',
       href: 'https://cal.com/simonparis/mini-audit'
     },
     secondaryCta: {

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -9,12 +9,12 @@ const fr: TranslationKeys = {
     cta: 'Diagnostic Éclair'
   },
   hero: {
-    title: 'Automatisez les tâches lourdes. Protégez vos marges. Restez conforme à la Loi 25.',
-    highlight: 'Protégez vos marges',
+    title: 'Gagnez plus de clients québécois avec un suivi en 5 minutes. Restez conforme à la Loi 25 automatiquement.',
+    highlight: 'Gagnez plus de clients québécois avec un suivi en 5 minutes',
     subtitle:
-      'Je conçois et teste des automatisations IA concrètes — puis je partage ce qui fonctionne pour les PME du Québec. De la création de contenu à la conformité, j’aide les équipes à gagner du temps et à rester en avance.',
+      'J’accompagne les cliniques, entrepreneurs et pros du Québec pour répondre en moins de 5 minutes grâce à des automatisations bilingues approuvées localement. Réservez votre Diagnostic Éclair gratuit de 20 minutes pour repérer votre fuite #1 de ventes/temps et rester conforme à la Loi 25.',
     cta: {
-      label: 'Réserver un Diagnostic Éclair',
+      label: 'Réserver le Diagnostic Éclair gratuit',
       href: 'https://cal.com/simonparis/diagnostic'
     },
     secondaryCta: {


### PR DESCRIPTION
## Summary
- refresh English hero copy to emphasize 5-minute response advantage, Law 25 compliance, and the free Diagnostic Éclair offer
- align French hero messaging with the same speed-to-lead positioning and compliance benefits

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e25294e9d08323b8e40c90cade34e8