### PR TITLE
Revamp homepage hero with bilingual thought-leadership copy

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useLanguage } from './LanguageProvider';
+import type { Language } from './i18n';
 import {
   MessageSquare,
   CheckCircle,
@@ -24,53 +25,81 @@ import MiniAuditCTA from './components/MiniAuditCTA';
 
 // Hero Component
 const Hero = () => {
-  const { t } = useLanguage();
+  const { t, lang, setLang } = useLanguage();
   const hero = t.hero;
-  const titleSegments = hero.title
-    .split('.')
-    .map(segment => segment.trim())
-    .filter(Boolean);
+  const subtitleLines = hero.subtitle.split('\n');
+
+  const handleLanguageToggle = (targetLang: Language) => {
+    if (targetLang !== lang) {
+      setLang(targetLang);
+    }
+  };
 
   return (
     <section
       id="hero"
-      className="relative isolate flex min-h-[90vh] items-center justify-center overflow-hidden bg-[#0B1320] text-white"
+      className="relative isolate flex min-h-[85vh] items-center justify-center overflow-hidden bg-gradient-to-br from-[#121C2D] to-[#0D1627] px-6 text-white sm:px-8"
     >
-      <div className="pointer-events-none absolute inset-0">
-        <div className="absolute inset-0 bg-[radial-gradient(120%_120%_at_0%_0%,rgba(34,128,255,0.2),rgba(11,19,32,0)_60%),radial-gradient(120%_120%_at_85%_15%,rgba(19,158,156,0.25),rgba(11,19,32,0)_65%)] opacity-90" />
-        <div className="absolute inset-0 bg-[linear-gradient(140deg,rgba(255,255,255,0.08),transparent_50%)] mix-blend-screen" />
-        <div className="absolute -left-24 top-[-6rem] h-[22rem] w-[22rem] rounded-full bg-[#2280FF]/18 blur-[140px]" />
-        <div className="absolute bottom-[-8rem] right-[-6rem] h-[28rem] w-[28rem] rounded-full bg-[#139E9C]/16 blur-[150px]" />
+      <div className="hero-aurora" />
+      <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(135deg,rgba(255,255,255,0.08),transparent_55%)] mix-blend-screen" />
+
+      <div className="absolute top-6 right-6 z-20 flex rounded-full border border-white/10 bg-white/5 text-xs font-semibold uppercase tracking-[0.18em] backdrop-blur-md sm:text-sm">
+        <button
+          type="button"
+          onClick={() => handleLanguageToggle('fr')}
+          className={`px-4 py-2 transition ${
+            lang === 'fr'
+              ? 'bg-white/15 text-white'
+              : 'text-white/70 hover:text-white'
+          }`}
+          aria-pressed={lang === 'fr'}
+        >
+          FR
+        </button>
+        <button
+          type="button"
+          onClick={() => handleLanguageToggle('en')}
+          className={`px-4 py-2 transition ${
+            lang === 'en'
+              ? 'bg-white/15 text-white'
+              : 'text-white/70 hover:text-white'
+          }`}
+          aria-pressed={lang === 'en'}
+        >
+          EN
+        </button>
       </div>
 
-      <div className="relative z-10 mx-auto w-full max-w-[60rem] px-4 py-24 text-center sm:px-6 lg:px-8 lg:py-32">
-        <div className="mx-auto flex max-w-3xl flex-col items-center gap-8 sm:gap-10">
-          <h1 className="text-balance text-[clamp(2rem,6vw,3.75rem)] font-semibold leading-[1.08] tracking-tight sm:leading-[1.12] text-white">
-            {titleSegments.map((segment, index) => {
-              const isHighlight = hero.highlight && segment.toLowerCase() === hero.highlight.toLowerCase();
-              const text = `${segment}.`;
-              return (
-                <span
-                  key={`${segment}-${index}`}
-                  className={`block ${isHighlight ? 'text-[#13A89E]' : 'text-white'}`}
-                >
-                  {text}
-                </span>
-              );
-            })}
+      <div className="relative z-10 mx-auto flex w-full max-w-5xl flex-col items-center justify-center py-24 text-center sm:py-28 lg:items-start lg:text-left xl:max-w-6xl">
+        <div className="flex max-w-3xl flex-col items-center space-y-6 lg:items-start">
+          <h1 className="text-[clamp(2.2rem,4vw,3.5rem)] font-semibold leading-[1.08] text-white">
+            <span className="block text-balance">{hero.headline?.line1 ?? hero.title}</span>
+            <span className="block text-balance text-[#13A89E] whitespace-nowrap">
+              {hero.headline?.highlight ?? hero.highlight}
+            </span>
           </h1>
 
-          <p className="text-balance text-base leading-relaxed text-white/80 sm:text-lg sm:leading-relaxed">
-            {hero.subtitle}
+          <p className="max-w-2xl text-[clamp(1rem,2.2vw,1.4rem)] leading-relaxed text-white/85 line-clamp-3 md:line-clamp-2">
+            {subtitleLines.map((line, index) => (
+              <React.Fragment key={`${line}-${index}`}>
+                {line.trim()}
+                {index < subtitleLines.length - 1 && (
+                  <>
+                    <br className="hidden md:block" />
+                    <span className="md:hidden"> </span>
+                  </>
+                )}
+              </React.Fragment>
+            ))}
           </p>
 
-          <div className="mt-2 flex flex-col items-center gap-3">
-            <a href={hero.cta.href} className="btn-primary hero-cta w-full max-w-xs sm:max-w-none sm:w-auto">
+          <div className="mt-4 flex w-full max-w-sm flex-col items-center gap-3 sm:max-w-none lg:items-start">
+            <a href={hero.cta.href} className="btn-primary hero-cta w-full sm:w-auto">
               {hero.cta.label}
             </a>
             <a
               href={hero.secondaryCta.href}
-              className="text-sm font-medium text-white/70 transition hover:text-white"
+              className="text-[0.9rem] font-medium text-white/70 transition hover:text-white"
             >
               {hero.secondaryCta.label}
             </a>

--- a/src/components/MiniAuditCTA.tsx
+++ b/src/components/MiniAuditCTA.tsx
@@ -6,8 +6,10 @@ const MiniAuditCTA: React.FC = () => {
   const { t } = useLanguage();
   const bullets: string[] = t.cta.audit.bullets;
 
+  const auditHref = t.cta.audit.href ?? t.hero.cta.href;
+
   return (
-    <section className="relative bg-section-gradient-bottom py-24 lg:py-32">
+    <section id="book" className="relative bg-section-gradient-bottom py-24 lg:py-32">
       <div className="mx-auto flex w-full justify-center px-4 sm:px-6 lg:px-8">
         <div className="mini-audit-card group relative w-full max-w-[1100px] overflow-hidden text-white lg:w-4/5">
           <div className="pointer-events-none absolute inset-0">
@@ -38,7 +40,7 @@ const MiniAuditCTA: React.FC = () => {
               <span className="text-sm font-medium uppercase tracking-[0.2em] text-[#8AE8E6]">
                 {t.cta.audit.timeline}
               </span>
-              <a href={t.hero.cta.href} className="btn-primary btn-primary--audit">
+              <a href={auditHref} className="btn-primary btn-primary--audit">
                 {t.cta.bookAudit}
               </a>
             </div>

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -8,13 +8,17 @@ export const en = {
     cta: 'Diagnostic Éclair'
   },
   hero: {
-    title: 'Reply faster. Win more clients.',
-    highlight: 'Win more clients',
+    title: 'Practical AI for Québec SMBs. Fast. Compliant. Profitable.',
+    highlight: 'Fast. Compliant. Profitable.',
+    headline: {
+      line1: 'Practical AI for Québec SMBs.',
+      highlight: 'Fast. Compliant. Profitable.'
+    },
     subtitle:
-      'For Québec clinics, trades & professional services: AI-powered bilingual automations that reply to every new inquiry in under 5 minutes — fully Law 25 compliant.',
+      'I turn your follow-ups, admin tasks and compliance into bilingual AI systems\nthat work while you sleep.',
     cta: {
-      label: 'Book My Free Audit',
-      href: 'https://cal.com/simonparis/mini-audit'
+      label: 'Free Mini Audit',
+      href: '#book'
     },
     secondaryCta: {
       label: 'Not ready yet? Join the newsletter →',
@@ -54,7 +58,8 @@ export const en = {
         'A quick-win automation that fits your current tools.',
         'Any compliance risks to fix before Law 25 fines.'
       ],
-      timeline: 'Typical setup: 5 – 10 business days.'
+      timeline: 'Typical setup: 5 – 10 business days.',
+      href: 'https://cal.com/simonparis/mini-audit'
     }
   },
   problems: {

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -9,16 +9,20 @@ const fr: TranslationKeys = {
     cta: 'Diagnostic Éclair'
   },
   hero: {
-    title: 'Répondez plus vite. Gagnez plus de clients.',
-    highlight: 'Gagnez plus de clients',
+    title: 'L’IA pratique pour les PME du Québec. Rapide. Conforme. Rentable.',
+    highlight: 'Rapide. Conforme. Rentable.',
+    headline: {
+      line1: 'L’IA pratique pour les PME du Québec.',
+      highlight: 'Rapide. Conforme. Rentable.'
+    },
     subtitle:
-      'Pour cliniques, commerces et pros du Québec : des automatisations IA bilingues qui répondent à chaque nouveau contact en moins de 5 minutes — tout en respectant la Loi 25.',
+      'Je transforme vos suivis, vos tâches et votre conformité en systèmes IA bilingues\nqui travaillent pendant que vous dormez.',
     cta: {
-      label: 'Réserver mon Diagnostic Éclair',
-      href: 'https://cal.com/simonparis/diagnostic'
+      label: 'Diagnostic Éclair Gratuit',
+      href: '#book'
     },
     secondaryCta: {
-      label: 'Pas prêt? Rejoignez l’infolettre →',
+      label: 'Pas prêt ? Rejoignez l’infolettre →',
       href: '/fr/infolettre'
     }
   },
@@ -55,7 +59,8 @@ const fr: TranslationKeys = {
         'L’automatisation rapide à implanter dans vos outils actuels.',
         'Les risques de conformité à corriger avant les amendes de la Loi 25.'
       ],
-      timeline: 'Installation typique : 5 à 10 jours ouvrables.'
+      timeline: 'Installation typique : 5 à 10 jours ouvrables.',
+      href: 'https://cal.com/simonparis/diagnostic'
     }
   },
   problems: {

--- a/src/index.css
+++ b/src/index.css
@@ -29,11 +29,19 @@
     );
   }
 
+  .line-clamp-2,
   .line-clamp-3 {
     display: -webkit-box;
-    -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;
     overflow: hidden;
+  }
+
+  .line-clamp-2 {
+    -webkit-line-clamp: 2;
+  }
+
+  .line-clamp-3 {
+    -webkit-line-clamp: 3;
   }
 }
 
@@ -167,6 +175,21 @@ h1, h2, h3, h4, h5, h6 {
   }
 }
 
+@keyframes hero-drift {
+  0% {
+    transform: translate3d(-12%, -6%, 0) scale(1);
+    opacity: 0.25;
+  }
+  50% {
+    transform: translate3d(8%, 6%, 0) scale(1.08);
+    opacity: 0.4;
+  }
+  100% {
+    transform: translate3d(-12%, -6%, 0) scale(1);
+    opacity: 0.25;
+  }
+}
+
 .mini-audit-card {
   position: relative;
   border-radius: 20px;
@@ -232,11 +255,23 @@ h1, h2, h3, h4, h5, h6 {
   animation: scroll 40s linear infinite;
 }
 
+.hero-aurora {
+  position: absolute;
+  inset: -35% -30% auto -30%;
+  height: 160%;
+  background: radial-gradient(circle at 30% 30%, rgba(19, 168, 158, 0.22), transparent 55%),
+    radial-gradient(circle at 70% 70%, rgba(34, 128, 255, 0.18), transparent 60%);
+  filter: blur(120px);
+  opacity: 0.35;
+  animation: hero-drift 18s ease-in-out infinite;
+  pointer-events: none;
+}
+
 /* Premium Buttons */
 .btn-primary {
   @apply inline-flex items-center justify-center rounded-xl px-8 py-4 text-lg font-semibold text-white transition-all;
-  background-color: #139e9c;
-  box-shadow: 0 8px 20px rgba(19, 158, 156, 0.35);
+  background-color: #13A89E;
+  box-shadow: 0 8px 20px rgba(19, 168, 158, 0.35);
   border: none;
   cursor: pointer;
 }
@@ -252,13 +287,13 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .btn-primary:hover {
-  background-color: #11a8a4;
-  box-shadow: 0 10px 30px rgba(19, 158, 156, 0.55);
+  background-color: #18B6B5;
+  box-shadow: 0 12px 34px rgba(24, 182, 181, 0.45);
 }
 
 .btn-primary:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 3px rgba(19, 158, 156, 0.35), 0 10px 30px rgba(19, 158, 156, 0.55);
+  box-shadow: 0 0 0 3px rgba(19, 168, 158, 0.35), 0 12px 34px rgba(24, 182, 181, 0.45);
 }
 
 .btn-primary:active {


### PR DESCRIPTION
## Summary
- replace the homepage hero with the "thought-leader" bilingual messaging and refreshed layout
- add a floating language toggle, animated gradient background, and updated CTA styling
- point hero CTAs to the audit booking section and expose booking links inside the mini audit CTA

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2b81fcac08323874c1d07a4ab0994