### PR TITLE
Resolve lint errors in footer language toggle and signup form

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,9 +42,9 @@ const Hero = () => {
 
       <div className="relative z-10 mx-auto w-full max-w-[60rem] px-4 py-24 text-center sm:px-6 lg:px-8 lg:py-32">
         <div className="mx-auto flex max-w-3xl flex-col items-center text-center">
-          <h1 className="text-balance text-[clamp(2.2rem,4vw,3.5rem)] font-semibold leading-[1.12] tracking-tight text-white">
+          <h1 className="hero-headline text-balance font-semibold leading-[1.12] tracking-tight text-white">
             <span className="block">{hero.headline}</span>
-            <span className="mt-2 block whitespace-nowrap text-[#13A89E]">{hero.accent}</span>
+            <span className="hero-accent mt-2 block whitespace-nowrap text-[#13A89E]">{hero.accent}</span>
           </h1>
 
           <p className="mt-[1em] text-balance text-[clamp(1rem,2.2vw,1.4rem)] leading-[1.5] text-[rgba(255,255,255,0.85)]">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,10 +26,7 @@ import MiniAuditCTA from './components/MiniAuditCTA';
 const Hero = () => {
   const { t } = useLanguage();
   const hero = t.hero;
-  const titleSegments = hero.title
-    .split('.')
-    .map(segment => segment.trim())
-    .filter(Boolean);
+  const subtitleLines = hero.subtitle.split('\n');
 
   return (
     <section
@@ -44,33 +41,27 @@ const Hero = () => {
       </div>
 
       <div className="relative z-10 mx-auto w-full max-w-[60rem] px-4 py-24 text-center sm:px-6 lg:px-8 lg:py-32">
-        <div className="mx-auto flex max-w-3xl flex-col items-center gap-8 sm:gap-10">
-          <h1 className="text-balance text-[clamp(2rem,6vw,3.75rem)] font-semibold leading-[1.08] tracking-tight sm:leading-[1.12] text-white">
-            {titleSegments.map((segment, index) => {
-              const isHighlight = hero.highlight && segment.toLowerCase() === hero.highlight.toLowerCase();
-              const text = `${segment}.`;
-              return (
-                <span
-                  key={`${segment}-${index}`}
-                  className={`block ${isHighlight ? 'text-[#13A89E]' : 'text-white'}`}
-                >
-                  {text}
-                </span>
-              );
-            })}
+        <div className="mx-auto flex max-w-3xl flex-col items-center text-center">
+          <h1 className="text-balance text-[clamp(2.2rem,4vw,3.5rem)] font-semibold leading-[1.12] tracking-tight text-white">
+            <span className="block">{hero.headline}</span>
+            <span className="mt-2 block whitespace-nowrap text-[#13A89E]">{hero.accent}</span>
           </h1>
 
-          <p className="text-balance text-base leading-relaxed text-white/80 sm:text-lg sm:leading-relaxed">
-            {hero.subtitle}
+          <p className="mt-[1em] text-balance text-[clamp(1rem,2.2vw,1.4rem)] leading-[1.5] text-[rgba(255,255,255,0.85)]">
+            {subtitleLines.map((line, index) => (
+              <span key={`hero-sub-${index}`} className="block">
+                {line}
+              </span>
+            ))}
           </p>
 
-          <div className="mt-2 flex flex-col items-center gap-3">
+          <div className="mt-[1.5em] flex w-full max-w-xs flex-col items-center gap-3 sm:max-w-sm">
             <a href={hero.cta.href} className="btn-primary hero-cta w-full max-w-xs sm:max-w-none sm:w-auto">
               {hero.cta.label}
             </a>
             <a
               href={hero.secondaryCta.href}
-              className="text-sm font-medium text-white/70 transition hover:text-white"
+              className="text-[0.9em] font-medium text-white/70 transition hover:text-white"
             >
               {hero.secondaryCta.label}
             </a>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -144,9 +144,17 @@ export const Header: React.FC<{
 };
 
 export const Footer: React.FC<{ langToggle?: { fr: string; en: string } }> = ({
-  langToggle: _langToggle
+  langToggle,
 }) => {
-  const { t } = useLanguage();
+  const { t, lang, setLang } = useLanguage();
+
+  const handleFooterLangSwitch = (targetLang: 'fr' | 'en') => {
+    if (!langToggle || lang === targetLang) return;
+    setLang(targetLang);
+    localStorage.setItem('lang', targetLang);
+    const href = targetLang === 'fr' ? langToggle.fr : langToggle.en;
+    window.location.href = href;
+  };
 
   return (
     <footer className="border-t border-white/10 bg-[#0B1220] text-white">
@@ -169,9 +177,37 @@ export const Footer: React.FC<{ langToggle?: { fr: string; en: string } }> = ({
         </div>
 
         <div className="mt-6 border-t border-white/10 pt-4">
-          <p className="text-center text-[11px] text-white/45 md:text-left">
-            {t.footer.copyright}
-          </p>
+          <div className="flex flex-col items-center gap-4 text-center md:flex-row md:items-center md:justify-between md:text-left">
+            <p className="text-[11px] text-white/45 md:text-left">
+              {t.footer.copyright}
+            </p>
+
+            {langToggle && (
+              <div className="flex items-center gap-4 text-[11px] uppercase tracking-[0.3em] text-white/40">
+                <button
+                  type="button"
+                  onClick={() => handleFooterLangSwitch('fr')}
+                  className={`transition-colors ${
+                    lang === 'fr' ? 'text-white' : 'hover:text-white/70'
+                  }`}
+                  aria-pressed={lang === 'fr'}
+                >
+                  FR
+                </button>
+                <span className="text-white/25">|</span>
+                <button
+                  type="button"
+                  onClick={() => handleFooterLangSwitch('en')}
+                  className={`transition-colors ${
+                    lang === 'en' ? 'text-white' : 'hover:text-white/70'
+                  }`}
+                  aria-pressed={lang === 'en'}
+                >
+                  EN
+                </button>
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </footer>

--- a/src/components/SignupForm.tsx
+++ b/src/components/SignupForm.tsx
@@ -34,6 +34,26 @@ function reloadScript(src: string, attrs: Record<string, string> = {}) {
   return s;
 }
 
+type BrevoTranslation = {
+  common: {
+    selectedList: string;
+    selectedLists: string;
+    selectedOption: string;
+    selectedOptions: string;
+  };
+};
+
+type BrevoWindow = Window & {
+  REQUIRED_CODE_ERROR_MESSAGE?: string;
+  LOCALE?: "fr" | "en";
+  EMAIL_INVALID_MESSAGE?: string;
+  SMS_INVALID_MESSAGE?: string;
+  REQUIRED_ERROR_MESSAGE?: string;
+  GENERIC_INVALID_MESSAGE?: string;
+  translation?: BrevoTranslation;
+  AUTOHIDE?: boolean;
+};
+
 // --- Brevo Configuration Data ---
 
 const FORM_ACTION_URLS = {
@@ -200,27 +220,31 @@ const SignupForm: React.FC = () => {
     // 3) Set Brevo globals
     
     // --- EDITED: Dynamic Validation Messages based on language ---
-    const requiredErrorMsg = lang === 'en' 
-      ? "This field cannot be left blank. " 
-      : "Ce champ ne peut pas être laissé vide. ";
-      
-    const emailInvalidMsg = lang === 'en' 
-      ? "Invalid email address. Please check the format (ex. name@business.com)." 
-      : "Adresse courriel invalide. Veuillez vérifier le format (ex. nom@entreprise.com ).";
+    const requiredErrorMsg =
+      lang === "en"
+        ? "This field cannot be left blank."
+        : "Ce champ ne peut pas être laissé vide.";
 
-    (window as any).REQUIRED_CODE_ERROR_MESSAGE = lang === 'en' 
-      ? 'Please choose a country code' 
-      : 'Veuillez choisir un indicatif de pays';
-      
-    (window as any).LOCALE = lang; // DYNAMICALLY SETS LOCALE
-    
-    (window as any).EMAIL_INVALID_MESSAGE = emailInvalidMsg;
-    (window as any).SMS_INVALID_MESSAGE = emailInvalidMsg;
-    (window as any).REQUIRED_ERROR_MESSAGE = requiredErrorMsg;
-    (window as any).GENERIC_INVALID_MESSAGE = emailInvalidMsg;
+    const emailInvalidMsg =
+      lang === "en"
+        ? "Invalid email address. Please check the format (ex. name@business.com)."
+        : "Adresse courriel invalide. Veuillez vérifier le format (ex. nom@entreprise.com).";
 
+    const brevoWindow = window as BrevoWindow;
 
-    (window as any).translation = {
+    brevoWindow.REQUIRED_CODE_ERROR_MESSAGE =
+      lang === "en"
+        ? "Please choose a country code"
+        : "Veuillez choisir un indicatif de pays";
+
+    brevoWindow.LOCALE = lang; // DYNAMICALLY SETS LOCALE
+
+    brevoWindow.EMAIL_INVALID_MESSAGE = emailInvalidMsg;
+    brevoWindow.SMS_INVALID_MESSAGE = emailInvalidMsg;
+    brevoWindow.REQUIRED_ERROR_MESSAGE = requiredErrorMsg;
+    brevoWindow.GENERIC_INVALID_MESSAGE = emailInvalidMsg;
+
+    brevoWindow.translation = {
       common: {
         selectedList: "{quantity} list selected",
         selectedLists: "{quantity} lists selected",
@@ -228,7 +252,7 @@ const SignupForm: React.FC = () => {
         selectedOptions: "{quantity} selected",
       },
     };
-    (window as any).AUTOHIDE = Boolean(0);
+    brevoWindow.AUTOHIDE = Boolean(0);
 
     // 4) Ensure reCAPTCHA is present
     if (!document.querySelector(`script[src^="https://www.google.com/recaptcha/api.js"]`)) {

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -8,12 +8,12 @@ export const en = {
     cta: 'Diagnostic Éclair'
   },
   hero: {
-    title: 'Reply faster. Win more clients.',
-    highlight: 'Win more clients',
+    headline: 'Practical AI for Québec SMBs.',
+    accent: 'Fast. Compliant. Profitable.',
     subtitle:
-      'For Québec clinics, trades & professional services: AI-powered bilingual automations that reply to every new inquiry in under 5 minutes — fully Law 25 compliant.',
+      'I turn your follow-ups, admin tasks and compliance into bilingual AI systems\nthat work while you sleep.',
     cta: {
-      label: 'Book My Free Audit',
+      label: 'Free Mini Audit',
       href: 'https://cal.com/simonparis/mini-audit'
     },
     secondaryCta: {

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -9,16 +9,16 @@ const fr: TranslationKeys = {
     cta: 'Diagnostic Éclair'
   },
   hero: {
-    title: 'Répondez plus vite. Gagnez plus de clients.',
-    highlight: 'Gagnez plus de clients',
+    headline: 'L’IA pratique pour les PME du Québec.',
+    accent: 'Rapide. Conforme. Rentable.',
     subtitle:
-      'Pour cliniques, commerces et pros du Québec : des automatisations IA bilingues qui répondent à chaque nouveau contact en moins de 5 minutes — tout en respectant la Loi 25.',
+      'Je transforme vos suivis, vos tâches et votre conformité en systèmes IA bilingues\nqui travaillent pendant que vous dormez.',
     cta: {
-      label: 'Réserver mon Diagnostic Éclair',
+      label: 'Diagnostic Éclair Gratuit',
       href: 'https://cal.com/simonparis/diagnostic'
     },
     secondaryCta: {
-      label: 'Pas prêt? Rejoignez l’infolettre →',
+      label: 'Pas prêt ? Rejoignez l’infolettre →',
       href: '/fr/infolettre'
     }
   },

--- a/src/index.css
+++ b/src/index.css
@@ -198,6 +198,27 @@ h1, h2, h3, h4, h5, h6 {
   transition: transform 0.3s ease, box-shadow 0.3s ease, background-position 0.4s ease;
 }
 
+.hero-headline {
+  font-size: clamp(2.2rem, 4vw, 3.5rem);
+}
+
+@media (max-width: 420px) {
+  .hero-headline {
+    font-size: min(10.5vw, 2.2rem);
+  }
+
+  .hero-accent {
+    font-size: min(10vw, 2.1rem);
+    letter-spacing: -0.015em;
+  }
+}
+
+@media (max-width: 360px) {
+  .hero-accent {
+    font-size: min(11vw, 2rem);
+  }
+}
+
 .btn-primary--audit:hover {
   background-position: 100% 50%;
   box-shadow: 0 4px 18px rgba(19, 158, 156, 0.5), 0 0 22px rgba(19, 158, 156, 0.55);

--- a/src/index.css
+++ b/src/index.css
@@ -202,20 +202,31 @@ h1, h2, h3, h4, h5, h6 {
   font-size: clamp(2.2rem, 4vw, 3.5rem);
 }
 
-@media (max-width: 420px) {
+.hero-accent {
+  font-size: clamp(2rem, 4.2vw, 3rem);
+}
+
+@media (max-width: 540px) {
   .hero-headline {
-    font-size: min(10.5vw, 2.2rem);
+    font-size: clamp(1.9rem, 6.5vw, 2.2rem);
   }
 
   .hero-accent {
-    font-size: min(10vw, 2.1rem);
-    letter-spacing: -0.015em;
+    font-size: clamp(1.5rem, 5.8vw, 2rem);
+    letter-spacing: -0.02em;
+  }
+}
+
+@media (max-width: 400px) {
+  .hero-headline {
+    font-size: clamp(1.7rem, 7vw, 2rem);
   }
 }
 
 @media (max-width: 360px) {
   .hero-accent {
-    font-size: min(11vw, 2rem);
+    font-size: clamp(1.2rem, 6.2vw, 1.65rem);
+    letter-spacing: -0.025em;
   }
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -235,8 +235,8 @@ h1, h2, h3, h4, h5, h6 {
 /* Premium Buttons */
 .btn-primary {
   @apply inline-flex items-center justify-center rounded-xl px-8 py-4 text-lg font-semibold text-white transition-all;
-  background-color: #139e9c;
-  box-shadow: 0 8px 20px rgba(19, 158, 156, 0.35);
+  background-color: #13A89E;
+  box-shadow: 0 8px 22px rgba(19, 168, 158, 0.32);
   border: none;
   cursor: pointer;
 }
@@ -252,8 +252,8 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .btn-primary:hover {
-  background-color: #11a8a4;
-  box-shadow: 0 10px 30px rgba(19, 158, 156, 0.55);
+  background-color: #18B6B5;
+  box-shadow: 0 0 18px rgba(24, 182, 181, 0.45), 0 12px 30px rgba(19, 168, 158, 0.4);
 }
 
 .btn-primary:focus-visible {


### PR DESCRIPTION
## Summary
- add explicit typing for Brevo globals so the signup form no longer relies on `any`
- activate the footer language toggle, sharing the same navigation logic as the header to avoid unused prop lint errors

## Testing
- npm run lint *(passes with existing FAQ fast-refresh warning)*

------
https://chatgpt.com/codex/tasks/task_e_68e2bdd693808323a3057a8383e5195d