### PR TITLE
Restore privacy footer link and tweak privacy layout

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -2,6 +2,11 @@ import React, { useState, useEffect } from 'react';
 import { useLanguage } from '../LanguageProvider';
 import { Menu, X } from 'lucide-react';
 
+const getTargetHref = (
+  targetLang: 'fr' | 'en',
+  langToggle?: { fr: string; en: string }
+) => (targetLang === 'fr' ? langToggle?.fr ?? '/fr' : langToggle?.en ?? '/');
+
 export const Header: React.FC<{
   langToggle?: { fr: string; en: string };
   forceDarkBackground?: boolean;
@@ -23,18 +28,14 @@ export const Header: React.FC<{
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
-  const resolvedTextClass = forceDarkBackground
-    ? 'text-white'
-    : isPrivacyPage
-    ? 'text-[#121C2D]'
-    : 'text-white';
+  const resolvedTextClass = 'text-white';
   const textClass = resolvedTextClass;
   const LanguageToggle = ({ tone = 'desktop' }: { tone?: 'desktop' | 'mobile' }) => {
-    const goTo = (targetLang: 'fr' | 'en') => {
-      if (lang === targetLang) return;
+    const toggleLanguage = () => {
+      const targetLang = lang === 'fr' ? 'en' : 'fr';
       setLang(targetLang);
       localStorage.setItem('lang', targetLang);
-      const href = targetLang === 'fr' ? langToggle?.fr ?? '/fr' : langToggle?.en ?? '/';
+      const href = getTargetHref(targetLang, langToggle);
       window.location.href = href;
     };
 
@@ -46,48 +47,42 @@ export const Header: React.FC<{
       ? 'text-[#121C2D]'
       : 'text-white';
     const inactiveClass = isMobile
-      ? 'text-white/60 hover:text-white'
+      ? 'text-white/55'
       : isLight
-      ? 'text-[#121C2D]/60 hover:text-[#121C2D]'
-      : 'text-white/60 hover:text-white';
+      ? 'text-[#121C2D]/55'
+      : 'text-white/55';
     const dividerClass = isMobile
-      ? 'text-white/25'
+      ? 'text-white/30'
       : isLight
-      ? 'text-[#121C2D]/30'
-      : 'text-white/30';
+      ? 'text-[#121C2D]/35'
+      : 'text-white/35';
 
     const wrapperClass =
       tone === 'desktop'
-        ? 'flex items-center text-[0.7rem] font-semibold uppercase tracking-[0.35em]'
-        : 'flex items-center text-[0.7rem] font-semibold uppercase tracking-[0.35em]';
+        ? 'flex items-center text-[0.7rem] font-semibold uppercase tracking-[0.25em]'
+        : 'flex items-center text-[0.7rem] font-semibold uppercase tracking-[0.25em]';
+
+    const nextLang = lang === 'fr' ? 'en' : 'fr';
+    const label = nextLang === 'fr' ? 'Switch language to French' : 'Switch language to English';
 
     return (
-      <div className={wrapperClass}>
-        <button
-          type="button"
-          aria-pressed={lang === 'fr'}
-          onClick={() => goTo('fr')}
-          className={`${lang === 'fr' ? activeClass : inactiveClass} transition-colors`}
-        >
-          FR
-        </button>
-        <span className={`mx-2 ${dividerClass}`}>|</span>
-        <button
-          type="button"
-          aria-pressed={lang === 'en'}
-          onClick={() => goTo('en')}
-          className={`${lang === 'en' ? activeClass : inactiveClass} transition-colors`}
-        >
-          EN
-        </button>
-      </div>
+      <button
+        type="button"
+        onClick={toggleLanguage}
+        className={`${wrapperClass} transition-colors hover:opacity-90 focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white`}
+        aria-label={label}
+      >
+        <span className={lang === 'fr' ? activeClass : inactiveClass}>FR</span>
+        <span className={`mx-[6px] ${dividerClass}`}>|</span>
+        <span className={lang === 'en' ? activeClass : inactiveClass}>EN</span>
+      </button>
     );
   };
 
   const headerBackgroundClass = forceDarkBackground
     ? 'bg-[#0B1320]/95 backdrop-blur-lg'
     : isPrivacyPage
-    ? 'bg-white/90 backdrop-blur-lg shadow-sm'
+    ? 'bg-[#0B1320]/95 backdrop-blur-lg shadow-sm'
     : isScrolled
     ? 'bg-[#0B1320]/90 backdrop-blur-lg'
     : 'bg-transparent';
@@ -149,14 +144,21 @@ export const Footer: React.FC<{ langToggle?: { fr: string; en: string } }> = ({
   langToggle,
 }) => {
   const { t, lang, setLang } = useLanguage();
+  const resolvedLangToggle = {
+    fr: langToggle?.fr ?? '/fr',
+    en: langToggle?.en ?? '/',
+  };
 
-  const handleFooterLangSwitch = (targetLang: 'fr' | 'en') => {
-    if (!langToggle || lang === targetLang) return;
+  const toggleFooterLanguage = () => {
+    const targetLang = lang === 'fr' ? 'en' : 'fr';
     setLang(targetLang);
     localStorage.setItem('lang', targetLang);
-    const href = targetLang === 'fr' ? langToggle.fr : langToggle.en;
+    const href = getTargetHref(targetLang, resolvedLangToggle);
     window.location.href = href;
   };
+
+  const nextLang = lang === 'fr' ? 'en' : 'fr';
+  const footerLabel = nextLang === 'fr' ? 'Switch language to French' : 'Switch language to English';
 
   return (
     <footer className="border-t border-white/10 bg-[#0B1220] text-white">
@@ -192,31 +194,16 @@ export const Footer: React.FC<{ langToggle?: { fr: string; en: string } }> = ({
                 {t.footer.links.privacy}
               </a>
 
-              {langToggle && (
-                <div className="flex items-center gap-4 text-[11px] uppercase tracking-[0.3em] text-white/40">
-                  <button
-                    type="button"
-                    onClick={() => handleFooterLangSwitch('fr')}
-                    className={`transition-colors ${
-                      lang === 'fr' ? 'text-white' : 'hover:text-white/70'
-                    }`}
-                    aria-pressed={lang === 'fr'}
-                  >
-                    FR
-                  </button>
-                  <span className="text-white/25">|</span>
-                  <button
-                    type="button"
-                    onClick={() => handleFooterLangSwitch('en')}
-                    className={`transition-colors ${
-                      lang === 'en' ? 'text-white' : 'hover:text-white/70'
-                    }`}
-                    aria-pressed={lang === 'en'}
-                  >
-                    EN
-                  </button>
-                </div>
-              )}
+              <button
+                type="button"
+                onClick={toggleFooterLanguage}
+                className="flex items-center text-[11px] font-semibold uppercase tracking-[0.25em] text-white/55 transition hover:text-white focus:outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+                aria-label={footerLabel}
+              >
+                <span className={lang === 'fr' ? 'text-white' : 'text-white/55'}>FR</span>
+                <span className="mx-[6px] text-white/30">|</span>
+                <span className={lang === 'en' ? 'text-white' : 'text-white/55'}>EN</span>
+              </button>
             </div>
           </div>
         </div>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -25,7 +25,7 @@ export const Header: React.FC<{
 
   const resolvedTextClass = forceDarkBackground
     ? 'text-white'
-    : !isScrolled && isPrivacyPage
+    : isPrivacyPage
     ? 'text-[#121C2D]'
     : 'text-white';
   const textClass = resolvedTextClass;
@@ -86,6 +86,8 @@ export const Header: React.FC<{
 
   const headerBackgroundClass = forceDarkBackground
     ? 'bg-[#0B1320]/95 backdrop-blur-lg'
+    : isPrivacyPage
+    ? 'bg-white/90 backdrop-blur-lg shadow-sm'
     : isScrolled
     ? 'bg-[#0B1320]/90 backdrop-blur-lg'
     : 'bg-transparent';
@@ -182,31 +184,40 @@ export const Footer: React.FC<{ langToggle?: { fr: string; en: string } }> = ({
               {t.footer.copyright}
             </p>
 
-            {langToggle && (
-              <div className="flex items-center gap-4 text-[11px] uppercase tracking-[0.3em] text-white/40">
-                <button
-                  type="button"
-                  onClick={() => handleFooterLangSwitch('fr')}
-                  className={`transition-colors ${
-                    lang === 'fr' ? 'text-white' : 'hover:text-white/70'
-                  }`}
-                  aria-pressed={lang === 'fr'}
-                >
-                  FR
-                </button>
-                <span className="text-white/25">|</span>
-                <button
-                  type="button"
-                  onClick={() => handleFooterLangSwitch('en')}
-                  className={`transition-colors ${
-                    lang === 'en' ? 'text-white' : 'hover:text-white/70'
-                  }`}
-                  aria-pressed={lang === 'en'}
-                >
-                  EN
-                </button>
-              </div>
-            )}
+            <div className="flex flex-col items-center gap-4 sm:flex-row sm:gap-6">
+              <a
+                href={lang === 'fr' ? '/fr/politique-confidentialite' : '/privacy'}
+                className="text-[11px] uppercase tracking-[0.3em] text-white/60 transition hover:text-white"
+              >
+                {t.footer.links.privacy}
+              </a>
+
+              {langToggle && (
+                <div className="flex items-center gap-4 text-[11px] uppercase tracking-[0.3em] text-white/40">
+                  <button
+                    type="button"
+                    onClick={() => handleFooterLangSwitch('fr')}
+                    className={`transition-colors ${
+                      lang === 'fr' ? 'text-white' : 'hover:text-white/70'
+                    }`}
+                    aria-pressed={lang === 'fr'}
+                  >
+                    FR
+                  </button>
+                  <span className="text-white/25">|</span>
+                  <button
+                    type="button"
+                    onClick={() => handleFooterLangSwitch('en')}
+                    className={`transition-colors ${
+                      lang === 'en' ? 'text-white' : 'hover:text-white/70'
+                    }`}
+                    aria-pressed={lang === 'en'}
+                  >
+                    EN
+                  </button>
+                </div>
+              )}
+            </div>
           </div>
         </div>
       </div>

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -317,6 +317,9 @@ export const en = {
       locationLabel: 'Based in',
       location: 'Québec, Canada'
     },
+    links: {
+      privacy: 'Privacy Policy'
+    },
     copyright: '© 2024 Simon Paris Consulting'
   }
 };

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -318,6 +318,9 @@ const fr: TranslationKeys = {
       locationLabel: 'Basé à',
       location: 'Québec, Canada'
     },
+    links: {
+      privacy: 'Politique de confidentialité'
+    },
     copyright: '© 2024 Simon Paris Consulting'
   }
 };

--- a/src/pages/PolitiqueConfidentialite.tsx
+++ b/src/pages/PolitiqueConfidentialite.tsx
@@ -12,7 +12,7 @@ const PolitiqueConfidentialite = () => {
   return (
     <div className="min-h-screen bg-white">
       <Header langToggle={{ fr: '/fr/politique-confidentialite', en: '/privacy' }} />
-      <main className="max-w-[800px] mx-auto pt-48 md:pt-56 p-4 md:p-8">
+      <main className="max-w-[800px] mx-auto pt-52 md:pt-60 p-4 md:p-8">
         <h1 className="text-3xl md:text-4xl font-bold text-[#121C2D] mb-6">Politique de confidentialité (Loi 25 &amp; LCAPC)</h1>
         <p className="mb-6 text-[0.9rem] md:text-base text-[#121C2D] leading-relaxed">
           Bienvenue chez Simon Paris Consulting. Nous respectons votre vie privée et nous engageons à protéger vos renseignements personnels conformément à la Loi 25 du Québec et à la Loi canadienne anti-pourriel (LCAPC). Cette politique décrit comment nous collectons, utilisons, divulguons et sécurisons vos données.

--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -12,7 +12,7 @@ const PrivacyPolicy = () => {
   return (
     <div className="min-h-screen bg-white">
       <Header langToggle={{ fr: '/fr/politique-confidentialite', en: '/privacy' }} />
-      <main className="max-w-[800px] mx-auto pt-48 md:pt-56 p-4 md:p-8">
+      <main className="max-w-[800px] mx-auto pt-52 md:pt-60 p-4 md:p-8">
         <h1 className="text-3xl md:text-4xl font-bold text-[#121C2D] mb-6">Privacy Policy (Law 25 &amp; CASL Compliance)</h1>
         <p className="mb-6 text-[0.9rem] md:text-base text-[#121C2D] leading-relaxed">
           Welcome to Simon Paris Consulting. We respect your privacy and are committed to protecting your personal information under Quebec’s Law 25 and Canada’s Anti-Spam Legislation (CASL). This policy explains how we collect, use, disclose, and safeguard your data.


### PR DESCRIPTION
## Summary
- restore the privacy policy link in the footer with English and French translations
- ensure the header stays opaque on the privacy pages and add extra top padding to their content

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2da58d5bc8323a0316bfa3d19500b