### PR TITLE
Refine pain section headlines and subtitles

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -23,24 +23,26 @@ export const en = {
   },
   sections: {
     problem: {
-      heading: 'Why Québec SMBs lose time (and <span class="accent">real</span> margins) every week…',
-      subheading: 'The same four problems I’ve solved again and again — starting with my own systems.',
+      heading:
+        'I\'ve lived the chaos — and know <span style="color:#13A89E;">why it keeps you stuck</span>.',
+      subheading:
+        'Québec SMBs lose hours every week managing admin, chasing clients, and scrambling for compliance. I help owners clear these roadblocks — one intelligent system at a time. Here are the most common ones I see:',
       cards: [
         {
-          title: 'Repetitive admin tasks',
-          description: 'Hours lost on manual scheduling, invoices, and data entry.'
+          title: 'Slow follow-ups',
+          description: 'Ready-to-buy clients who move on.'
         },
         {
-          title: 'Delayed follow-ups',
-          description: 'Leads, quotes, and reminders sent too late to convert.'
+          title: 'Repetitive tasks',
+          description: 'Copy, resend, repeat… day after day.'
         },
         {
-          title: 'Last-minute compliance',
-          description: 'Privacy and consent handled only when an audit looms.'
+          title: 'Compliance stress (Law 25)',
+          description: 'Too many rules, not enough structure.'
         },
         {
           title: 'Disconnected tools',
-          description: 'Systems that don’t talk — forcing your team to do double work.'
+          description: 'Systems that don’t talk, time that slips away.'
         }
       ]
     }

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -24,24 +24,26 @@ const fr: TranslationKeys = {
   },
   sections: {
     problem: {
-      heading: 'Pourquoi les PME du Québec perdent du temps (et des marges <span class="accent">réelles</span>) chaque semaine…',
-      subheading: 'Les quatre problèmes que j’ai appris à résoudre — en commençant par mes propres systèmes.',
+      heading:
+        'J\'ai connu le chaos — et je sais <span style="color:#13A89E;">pourquoi ça bloque</span>.',
+      subheading:
+        'Chaque semaine, les PME du Québec perdent des heures à gérer la paperasse, relancer les clients et courir après la conformité. J\'aide les dirigeants à éliminer ces blocages — un système intelligent à la fois. Voici les plus fréquents :',
       cards: [
         {
-          title: 'Tâches administratives répétitives',
-          description: 'Des heures perdues à planifier, facturer et saisir manuellement des données.'
-        },
-        {
           title: 'Suivis trop tardifs',
-          description: 'Des clients ou soumissions qui tombent entre les mailles du filet.'
+          description: 'Des clients prêts à acheter qui passent à autre chose.'
         },
         {
-          title: 'Conformité à la dernière minute',
-          description: 'Des consentements et politiques gérés seulement sous pression.'
+          title: 'Tâches répétitives',
+          description: 'Copier, renvoyer, recommencer... chaque jour.'
         },
         {
-          title: 'Outils déconnectés',
-          description: 'Des systèmes qui ne se parlent pas — et font perdre du temps à votre équipe.'
+          title: 'Stress de conformité (Loi 25)',
+          description: 'Trop de règles, pas assez d’organisation.'
+        },
+        {
+          title: 'Outils dispersés',
+          description: 'Des systèmes qui ne se parlent pas, du temps perdu.'
         }
       ]
     }


### PR DESCRIPTION
## Summary
- update the English pain section heading and subtitle with the new empathetic messaging and teal highlight
- refresh the French pain section heading and subtitle to mirror the approved Québec-focused copy

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e302923e788323a2ee2de4909bc2b8