### PR TITLE
Comment out pricing sections on homepage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -280,6 +280,7 @@ const ProofLab = () => {
 };
 
 // Offer Cards Component
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const OfferCards = () => {
   const [isVisible, setIsVisible] = useState(false);
   const sectionRef = useRef<HTMLElement>(null);
@@ -346,6 +347,7 @@ const OfferCards = () => {
 };
 
 // ROI Math Component
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const ROIMath = () => {
   const [isVisible, setIsVisible] = useState(false);
   const sectionRef = useRef<HTMLElement>(null);
@@ -394,6 +396,7 @@ const ROIMath = () => {
 };
 
 // Checklist Component
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const Checklist = () => {
   const { t, lang } = useLanguage();
   const newsletterHref = lang === 'fr' ? '/fr/newsletter' : '/en/newsletter';


### PR DESCRIPTION
## Summary
- comment out the OfferCards, ROIMath, and Checklist sections so they no longer render on the homepage

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e50522a12c8323886b1bcc61009a9e