### PR TITLE
Update hero subtitle copy and unify final CTA styling

### DIFF
--- a/src/components/FinalCTA.tsx
+++ b/src/components/FinalCTA.tsx
@@ -21,7 +21,7 @@ const FinalCTA: React.FC = () => {
           <div className="flex flex-col items-center md:items-end">
             <a
               href={ctaHref}
-              className="bg-[#139E9C] text-white hover:bg-[#118C89] px-6 py-3 rounded-xl font-semibold shadow-md hover:shadow-lg transition focus:outline-none focus:ring-2 focus:ring-[#139E9C]/40"
+              className="btn-primary"
             >
               {t.finalcta.cta}
             </a>

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -11,7 +11,7 @@ export const en = {
     headline: 'Practical AI for Québec SMBs.',
     accent: 'Fast. Compliant. Profitable.',
     subtitle:
-      'I turn your follow-ups, admin tasks and compliance into bilingual AI systems\nthat work while you sleep.',
+      'An ongoing exploration of how AI and automation can simplify work for Québec SMBs — I document insights, workflows, and lessons learned along the way.',
     cta: {
       label: 'Free Mini Audit',
       href: 'https://cal.com/simonparis/mini-audit'

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -12,7 +12,7 @@ const fr: TranslationKeys = {
     headline: 'L’IA pratique pour les PME du Québec.',
     accent: 'Rapide. Conforme. Rentable.',
     subtitle:
-      'Je transforme vos suivis, vos tâches et votre conformité en systèmes IA bilingues\nqui travaillent pendant que vous dormez.',
+      'Un espace d’expérimentation où j’explore comment l’IA et l’automatisation peuvent moderniser les opérations des PME du Québec, tout en partageant mes découvertes et mes apprentissages en chemin.',
     cta: {
       label: 'Diagnostic Éclair Gratuit',
       href: 'https://cal.com/simonparis/diagnostic'


### PR DESCRIPTION
## Summary
- update the hero subtitle in English and French with the new messaging
- reuse the hero button styling for the final newsletter CTA so its hover color matches the hero

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5083a4c20832380ae93c65d1521dc