### PR TITLE
Align headings and typography with Inter

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -118,7 +118,7 @@ const ProblemSection = () => {
           }`}
         >
           <h2
-            className="text-4xl font-semibold text-[#121C2D] md:text-5xl"
+            className="section-heading text-balance text-[#121C2D]"
             dangerouslySetInnerHTML={{ __html: t.sections.problem.heading }}
           />
           {t.sections.problem.subheading && (
@@ -221,7 +221,7 @@ const ProofLab = () => {
           }`}
         >
           <h2
-            className="text-balance text-3xl font-semibold text-[#121C2D] md:text-4xl"
+            className="section-heading text-balance text-[#121C2D]"
             dangerouslySetInnerHTML={{ __html: headingHtml }}
           />
           <p className="mt-4 text-base leading-relaxed text-slate-600 md:text-lg">{t.proofLab.subtitle}</p>
@@ -311,7 +311,7 @@ const OfferCards = () => {
     >
       <div className="relative z-10 max-w-7xl mx-auto px-6 lg:px-8 text-center">
         <h2
-          className={`text-display text-gray-900 mb-12 transition-all duration-1000 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}
+          className={`section-heading text-gray-900 mb-12 transition-all duration-1000 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}
           dangerouslySetInnerHTML={{ __html: t.offers.heading }}
         />
 
@@ -377,7 +377,7 @@ const ROIMath = () => {
       <div className="relative z-10 max-w-5xl mx-auto px-6 lg:px-8 text-center">
         <div className={`mb-12 transition-all duration-1000 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}>
           <h2
-            className="text-display text-gray-900 mb-6"
+            className="section-heading text-gray-900 mb-6"
             dangerouslySetInnerHTML={{ __html: t.roi.title }}
           />
         </div>
@@ -470,7 +470,7 @@ const ProofSection = () => {
     >
       <div className="relative z-10 max-w-7xl mx-auto px-6 lg:px-8">
         <div className={`text-center mb-12 transition-all duration-1000 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}>
-          <h2 className="text-display text-gray-900 mb-6">{t.proof.title}</h2>
+          <h2 className="section-heading text-gray-900 mb-6">{t.proof.title}</h2>
         </div>
 
         <p
@@ -520,7 +520,7 @@ const FAQ = () => {
       <div className="relative z-10 max-w-4xl mx-auto px-6 lg:px-8">
         <div className={`text-center mb-16 transition-all duration-1000 ${isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-10'}`}>
           <h2
-            className="text-display text-gray-900 mb-6"
+            className="section-heading text-gray-900 mb-6"
             dangerouslySetInnerHTML={{ __html: t.faq.title }}
           />
         </div>

--- a/src/components/FinalCTA.tsx
+++ b/src/components/FinalCTA.tsx
@@ -11,7 +11,7 @@ const FinalCTA: React.FC = () => {
       <div className="mx-auto max-w-5xl px-6">
         <div className="flex flex-col items-center gap-6 text-center md:flex-row md:items-center md:justify-between md:gap-0 md:text-left">
           <div className="md:max-w-3xl md:pr-8">
-            <h2 className="text-2xl font-bold leading-tight md:text-3xl">
+            <h2 className="section-heading text-white">
               {t.finalcta.headline}
             </h2>
             <p className="mt-2 text-base text-white/70">

--- a/src/components/MiniAuditCTA.tsx
+++ b/src/components/MiniAuditCTA.tsx
@@ -20,7 +20,7 @@ const MiniAuditCTA: React.FC = () => {
           </div>
 
           <div className="relative mx-auto flex flex-col items-center gap-10 px-8 py-12 text-center sm:px-10 sm:py-14 lg:max-w-4xl lg:px-16 lg:py-16">
-            <h2 className="text-[clamp(1.75rem,3.8vw,2.75rem)] font-semibold leading-tight text-[#F4F6F8]">
+            <h2 className="section-heading text-[#F4F6F8]">
               {t.cta.audit.title}
             </h2>
 

--- a/src/components/PartnerBar.tsx
+++ b/src/components/PartnerBar.tsx
@@ -35,7 +35,7 @@ const PartnerBar: React.FC = () => {
       style={{ backgroundImage: 'linear-gradient(to bottom left, #ebf3fb, #effbfa 55%, #fff)' }}
     >
       <div className="max-w-8xl mx-auto px-4 sm:px-6 lg:px-8">
-        <h2 className="text-center text-sm font-semibold tracking-wider uppercase font-mono mb-8 text-gray-900">
+        <h2 className="text-center text-sm font-semibold tracking-wider uppercase mb-8 text-gray-900">
           {t.partners.title}
         </h2>
         <div className="overflow-hidden w-full">

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Montserrat:wght@400;600;700&family=Open+Sans:wght@400;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
 
 @tailwind base;
 @tailwind components;
@@ -67,18 +67,6 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
-input,
-textarea,
-select {
-  font-family: 'Inter', sans-serif;
-}
-
-input::placeholder,
-textarea::placeholder {
-  font-family: 'Inter', sans-serif;
-  color: #9CA3AF;
-}
-
 .input--hidden {
   position: absolute !important;
   left: -5000px;
@@ -86,8 +74,22 @@ textarea::placeholder {
   pointer-events: none;
 }
 
-h1, h2, h3, h4, h5, h6 {
-  font-family: 'Montserrat', sans-serif;
+input,
+textarea,
+select,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: 'Inter', sans-serif;
+}
+
+input::placeholder,
+textarea::placeholder {
+  font-family: 'Inter', sans-serif;
+  color: #9CA3AF;
 }
 
 mark {
@@ -203,6 +205,14 @@ mark {
 
 .hero-headline {
   font-size: clamp(2.2rem, 4vw, 3.5rem);
+}
+
+.section-heading {
+  font-family: 'Inter', sans-serif;
+  font-weight: 600;
+  font-size: clamp(2.2rem, 4vw, 3.5rem);
+  line-height: 1.12;
+  letter-spacing: -0.01em;
 }
 
 .hero-accent {

--- a/src/pages/NewsletterConfirmation.tsx
+++ b/src/pages/NewsletterConfirmation.tsx
@@ -51,8 +51,8 @@ const NewsletterConfirmation: React.FC = () => {
         forceDarkBackground
       />
       <main className="flex flex-1 items-center justify-center px-4 py-24 md:px-6">
-        <div className="w-full max-w-[540px] rounded-[12px] bg-white/95 p-10 shadow-[0_28px_72px_rgba(18,28,45,0.12)] ring-1 ring-black/5 sm:p-12 font-inter">
-          <h1 className="text-3xl font-semibold text-[#121C2D] md:text-4xl">{copy.title}</h1>
+        <div className="w-full max-w-[540px] rounded-[12px] bg-white/95 p-10 shadow-[0_28px_72px_rgba(18,28,45,0.12)] ring-1 ring-black/5 sm:p-12">
+          <h1 className="section-heading text-[#121C2D] text-balance">{copy.title}</h1>
           <p className="mt-4 text-base leading-relaxed text-[#4B5563]">{copy.body}</p>
           <p className="mt-6 text-sm font-medium text-[#139E9C]">{copy.extra}</p>
           <a href={copy.backHome.href} className="btn-primary mt-10 inline-flex w-full justify-center sm:w-auto">

--- a/src/pages/PolitiqueConfidentialite.tsx
+++ b/src/pages/PolitiqueConfidentialite.tsx
@@ -13,7 +13,7 @@ const PolitiqueConfidentialite = () => {
     <div className="min-h-screen bg-white">
       <Header langToggle={{ fr: '/fr/politique-confidentialite', en: '/privacy' }} />
       <main className="max-w-[800px] mx-auto pt-52 md:pt-60 p-4 md:p-8">
-        <h1 className="text-3xl md:text-4xl font-bold text-[#121C2D] mb-6">Politique de confidentialité (Loi 25 &amp; LCAPC)</h1>
+        <h1 className="section-heading text-[#121C2D] text-balance mb-6">Politique de confidentialité (Loi 25 &amp; LCAPC)</h1>
         <p className="mb-6 text-[0.9rem] md:text-base text-[#121C2D] leading-relaxed">
           Bienvenue chez Simon Paris Consulting. Nous respectons votre vie privée et nous engageons à protéger vos renseignements personnels conformément à la Loi 25 du Québec et à la Loi canadienne anti-pourriel (LCAPC). Cette politique décrit comment nous collectons, utilisons, divulguons et sécurisons vos données.
         </p>

--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -13,7 +13,7 @@ const PrivacyPolicy = () => {
     <div className="min-h-screen bg-white">
       <Header langToggle={{ fr: '/fr/politique-confidentialite', en: '/privacy' }} />
       <main className="max-w-[800px] mx-auto pt-52 md:pt-60 p-4 md:p-8">
-        <h1 className="text-3xl md:text-4xl font-bold text-[#121C2D] mb-6">Privacy Policy (Law 25 &amp; CASL Compliance)</h1>
+        <h1 className="section-heading text-[#121C2D] text-balance mb-6">Privacy Policy (Law 25 &amp; CASL Compliance)</h1>
         <p className="mb-6 text-[0.9rem] md:text-base text-[#121C2D] leading-relaxed">
           Welcome to Simon Paris Consulting. We respect your privacy and are committed to protecting your personal information under Quebec’s Law 25 and Canada’s Anti-Spam Legislation (CASL). This policy explains how we collect, use, disclose, and safeguard your data.
         </p>

--- a/src/pages/SpeedToLead.tsx
+++ b/src/pages/SpeedToLead.tsx
@@ -227,7 +227,7 @@ const Landing: React.FC<{ lang: Lang }> = ({ lang }) => {
           </div>
           <div className="relative z-10 max-w-6xl mx-auto px-6 grid md:grid-cols-2 gap-12 items-center">
             <div>
-              <h1 className="text-4xl font-bold mb-4">{t.hero.headline}</h1>
+              <h1 className="section-heading text-white mb-4">{t.hero.headline}</h1>
               <p className="mb-6 max-w-md">{t.hero.sub}</p>
               <a href="#demo" data-action="demo" className="btn-primary text-lg px-8 py-4">
                 {t.hero.cta}


### PR DESCRIPTION
## Summary
- standardize the global typography stack on Inter and add a reusable section-heading style
- apply the new heading treatment across homepage sections and supporting pages to keep hero-level sizing consistent
- remove the monospace heading from the partner bar to keep typography uniform

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e54c47b0f08323811c6e3aa6cf06d2